### PR TITLE
Extended line length limit for more linting tools, updated linting tools and added issue templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,7 +10,7 @@ assignees: ''
 
 ## Prerequisites
 Please make sure to check off these prerequisites before submitting a bug report.
-- [ ] Test that the bug appears on the current version of the dev-branch. Make sure to include the commit hash of the commit you checked out.
+- [ ] Test that the bug appears on the current version of the main branch. Make sure to include the commit hash of the commit you checked out.
 - [ ] Check that the issue hasn't already been reported, by checking the currently open issues.
 - [ ] If there are steps to reproduce the problem, make sure to write them down below.
 - [ ] If relevant, please include the ONNX files, which were created directly before and/or after the bug.
@@ -25,11 +25,10 @@ Please add to the following sections to describe the bug as accurately as possib
 Add what needs to be done to reproduce the bug. Add code examples where useful
 and make sure to include the resulting ONNX files, and the commit hash you are working on.
 
-1. Clone the qonnx-frontend repository
-2. Checkout the dev branch, with commit hash: [...]
-3. Start the docker container with the command: [...]
-4. Run transformation [...] on ONNX file [...].
-5. [Further steps ...]
+1. Clone the qonnx repository
+2. Checkout the main branch, with commit hash: [...]
+3. Run transformation [...] on ONNX file [...]
+4. [Further steps ...]
 
 ### Expected behavior
 Please add a brief description of what you expected to happen.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,46 @@
+---
+name: Bug report
+about: Something isn't working as expected
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+
+## Prerequisites
+Please make sure to check off these prerequisites before submitting a bug report.
+- [ ] Test that the bug appears on the current version of the dev-branch. Make sure to include the commit hash of the commit you checked out.
+- [ ] Check that the issue hasn't already been reported, by checking the currently open issues.
+- [ ] If there are steps to reproduce the problem, make sure to write them down below.
+- [ ] If relevant, please include the ONNX files, which were created directly before and/or after the bug.
+
+## Quick summary
+Please give a brief and concise description of the bug.
+
+## Details
+Please add to the following sections to describe the bug as accurately as possible.
+
+### Steps to Reproduce
+Add what needs to be done to reproduce the bug. Add code examples where useful
+and make sure to include the resulting ONNX files, and the commit hash you are working on.
+
+1. Clone the qonnx-frontend repository
+2. Checkout the dev branch, with commit hash: [...]
+3. Start the docker container with the command: [...]
+4. Run transformation [...] on ONNX file [...].
+5. [Further steps ...]
+
+### Expected behavior
+Please add a brief description of what you expected to happen.
+
+### Actual behavior
+Describe what actually happens instead.
+
+## Optional
+
+### Possible fix
+If you already know where the issue stems from, or you have a hint please let us know.
+
+### Additional context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Contact the hls4ml maintainers
+    url: [hls4ml.help@gmail.com](mailto:hls4ml.help@gmail.com?subject=[GitHub]%20qonnx-frontend%20issue)
+    about: Talk to the hls4ml maintainers to engage with them or get answers to your burning questions.
+  - name: Talk and engage with the FINN community
+    url: https://gitter.im/xilinx-finn/community
+    about: Check out our gitter channel, if you have a question about FINN or a general problem that is likely not a bug.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Contact the hls4ml maintainers
-    url: '[hls4ml.help@gmail.com](mailto:hls4ml.help@gmail.com?subject=[GitHub]%20qonnx-frontend%20issue)'
-    about: Talk to the hls4ml maintainers to engage with them or get answers to your burning questions.
-  - name: Talk and engage with the FINN community
-    url: https://gitter.im/xilinx-finn/community
-    about: Check out the FINN gitter channel, if you have a question about FINN or a general problem that is likely not a bug.
+  - name: Talk and engage with the comunity
+    url: https://github.com/fastmachinelearning/qonnx/discussions/categories/general
+    about: Check out the GithHub discusisons page for quonnx. This is the best way to get in touch with us. In particular, if you have a question about qonnx or a general problem that is likely not a bug.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: false
 contact_links:
   - name: Talk and engage with the comunity
     url: https://github.com/fastmachinelearning/qonnx/discussions/categories/general
-    about: Check out the GithHub discusisons page for quonnx. This is the best way to get in touch with us. In particular, if you have a question about qonnx or a general problem that is likely not a bug.
+    about: Check out the GithHub discusisons page for QONNX. This is the best way to get in touch with us. In particular, if you have a question about QONNX or a general problem that is likely not a bug.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Contact the hls4ml maintainers
-    url: [hls4ml.help@gmail.com](mailto:hls4ml.help@gmail.com?subject=[GitHub]%20qonnx-frontend%20issue)
+    url: '[hls4ml.help@gmail.com](mailto:hls4ml.help@gmail.com?subject=[GitHub]%20qonnx-frontend%20issue)'
     about: Talk to the hls4ml maintainers to engage with them or get answers to your burning questions.
   - name: Talk and engage with the FINN community
     url: https://gitter.im/xilinx-finn/community
-    about: Check out our gitter channel, if you have a question about FINN or a general problem that is likely not a bug.
+    about: Check out the FINN gitter channel, if you have a question about FINN or a general problem that is likely not a bug.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: false
 contact_links:
   - name: Talk and engage with the comunity
     url: https://github.com/fastmachinelearning/qonnx/discussions/categories/general
-    about: Check out the GithHub discusisons page for QONNX. This is the best way to get in touch with us. In particular, if you have a question about QONNX or a general problem that is likely not a bug.
+    about: Check out the GitHub discusisons page for QONNX. This is the best way to get in touch with us. In particular, if you have a question about QONNX or a general problem that is likely not a bug.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -10,8 +10,7 @@ assignees: ''
 ## Prerequisites
 Please talk to either the FINN or hls4ml community before creating a new feature request. So that you can check that the idea is not already in active development.
 
-You can contact the hls4ml maintainers here: [hls4ml.help@gmail.com](mailto:hls4ml.help@gmail.com
-?subject=[GitHub]%20qonnx-frontend%20feature%20request)
+You can contact the hls4ml maintainers here: [hls4ml.help@gmail.com](mailto:hls4ml.help@gmail.com?subject=[GitHub]%20qonnx-frontend%20feature%20request)
 
 Or talk to the FINN community here: https://gitter.im/xilinx-finn/community
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,31 @@
+---
+name: Feature request
+about: Suggest an idea for the qonnx-frontend
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+## Prerequisites
+Please talk to either the FINN or hls4ml community before creating a new feature request. So that you can check that the idea is not already in active development.
+
+You can contact the hls4ml maintainers here: [hls4ml.help@gmail.com](mailto:hls4ml.help@gmail.com
+?subject=[GitHub]%20qonnx-frontend%20feature%20request)
+
+Or talk to the FINN community here: https://gitter.im/xilinx-finn/community
+
+Even if an idea is already being worked on you can still create a feature request,
+if you would like to open a discussion about the feature or want to contribute to it.
+
+## Details
+Please add to the following sections to describe the feature as accurately as possible.
+
+### New behavior
+Please add a brief and concise description of what you would like to happen in the qonnx-frontend in the future.
+
+### Motivation
+Please tell us why this feature is important to the community.
+
+### Parts of the qonnx-frontend being affected
+Please describe which parts of the qonnx-frontend would be affected by this feature.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Suggest an idea for the qonnx-frontend
+about: Suggest an idea for QONNX
 title: ''
 labels: enhancement
 assignees: ''
@@ -8,9 +8,9 @@ assignees: ''
 ---
 
 ## Prerequisites
-Please talk to either us before creating a new feature request. So that you can check that the idea is not already in active development.
+Please talk to us before creating a new feature request. So that you can check that the idea is not already in active development.
 
-You can present your idea over here at the GitHub discussions page for qonnx: https://github.com/fastmachinelearning/qonnx/discussions/categories/ideas
+You can present your idea over here at the GitHub discussions page for QONNX: https://github.com/fastmachinelearning/qonnx/discussions/categories/ideas
 
 Even if an idea is already being worked on you can still create a feature request,
 if you would like to open a discussion about the feature or want to contribute to it.
@@ -19,10 +19,10 @@ if you would like to open a discussion about the feature or want to contribute t
 Please add to the following sections to describe the feature as accurately as possible.
 
 ### New behavior
-Please add a brief and concise description of what you would like to happen in the qonnx-frontend in the future.
+Please add a brief and concise description of what you would like to happen in QONNX in the future.
 
 ### Motivation
 Please tell us why this feature is important to the community.
 
-### Parts of the qonnx-frontend being affected
-Please describe which parts of the qonnx-frontend would be affected by this feature.
+### Parts of QONNX being affected
+Please describe which parts of QONNX would be affected by this feature.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,11 +8,9 @@ assignees: ''
 ---
 
 ## Prerequisites
-Please talk to either the FINN or hls4ml community before creating a new feature request. So that you can check that the idea is not already in active development.
+Please talk to either us before creating a new feature request. So that you can check that the idea is not already in active development.
 
-You can contact the hls4ml maintainers here: [hls4ml.help@gmail.com](mailto:hls4ml.help@gmail.com?subject=[GitHub]%20qonnx%20feature%20request)
-
-Or talk to the FINN community here: https://gitter.im/xilinx-finn/community
+You can present your idea over here at the GitHub discussions page for qonnx: https://github.com/fastmachinelearning/qonnx/discussions/categories/ideas
 
 Even if an idea is already being worked on you can still create a feature request,
 if you would like to open a discussion about the feature or want to contribute to it.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -10,7 +10,7 @@ assignees: ''
 ## Prerequisites
 Please talk to either the FINN or hls4ml community before creating a new feature request. So that you can check that the idea is not already in active development.
 
-You can contact the hls4ml maintainers here: [hls4ml.help@gmail.com](mailto:hls4ml.help@gmail.com?subject=[GitHub]%20qonnx-frontend%20feature%20request)
+You can contact the hls4ml maintainers here: [hls4ml.help@gmail.com](mailto:hls4ml.help@gmail.com?subject=[GitHub]%20qonnx%20feature%20request)
 
 Or talk to the FINN community here: https://gitter.im/xilinx-finn/community
 

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,11 @@
+[settings]
+line_length=125
+indent='    '
+skip=.tox,.venv,build,dist
+known_standard_library=setuptools,pkg_resources
+known_test=pytest
+known_first_party=finn,hls4ml
+sections=FUTURE,STDLIB,TEST,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+default_section=THIRDPARTY
+multi_line_output=3
+profile=black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,7 @@ repos:
   hooks:
   - id: black
     language_version: python3
+    args: [--line-length=125]
 
 - repo: https://gitlab.com/pycqa/flake8
   rev: 3.8.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ default_language_version:
 
 repos:
 - repo: git://github.com/pre-commit/pre-commit-hooks
-  rev: v3.2.0
+  rev: v4.0.1
   hooks:
   - id: trailing-whitespace
   - id: check-added-large-files
@@ -21,19 +21,19 @@ repos:
     args: ['--fix=no']
 
 - repo: git://github.com/PyCQA/isort
-  rev: 5.5.3
+  rev: 5.9.3
   hooks:
   - id: isort
 
 - repo: git://github.com/psf/black
-  rev: stable
+  rev: 21.7b0
   hooks:
   - id: black
     language_version: python3
     args: [--line-length=125]
 
 - repo: https://gitlab.com/pycqa/flake8
-  rev: 3.8.3
+  rev: 3.9.2
   hooks:
   - id: flake8
     # black-compatible flake-8 config


### PR DESCRIPTION
Hi,
here are some changes and additions which I would propose:

* Black and isort now also adhere to the 125 character line length.
* Updated the versions of all pre-commit hooks by running `pre-commit autoupdate`
* Adapted the issue templates from FINN. (These will like need some more looking over and might need a better way to contact the hls4ml team and community, or it might be useful to create a gitter channel just for this repo.)
