### PR TITLE
First version of QONNX cleanup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,7 @@ repos:
   rev: 5.5.3
   hooks:
   - id: isort
+    args: ["--profile", "black"]
 
 - repo: git://github.com/psf/black
   rev: stable

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,2 +1,1 @@
 .. _changes:
-.. include:: ../CHANGELOG.rst

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,8 @@ package_dir =
 # For more information, check out https://semver.org/.
 install_requires =
     importlib-metadata; python_version<"3.8"
-    finn-base[onnx]==0.0.2b0 # TODO remove finn-base dependency by moving code into this repo
+    # TODO remove finn-base dependency by moving code into this repo
+    finn-base[onnx] @ git+ssh://git@github.com/Xilinx/finn-base@feature/qonnx_quant_op#egg=finn-base
     clize==4.1.1
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,8 @@ package_dir =
 # For more information, check out https://semver.org/.
 install_requires =
     importlib-metadata; python_version<"3.8"
+    finn-base[onnx]==0.0.2b0 # TODO remove finn-base dependency by moving code into this repo
+    clize==4.1.1
 
 
 [options.packages.find]
@@ -64,6 +66,8 @@ testing =
     pytest-cov
 
 [options.entry_points]
+console_scripts =
+    qonnx-cleanup = qonnx.util.cleanup:main
 # Add here console scripts like:
 # console_scripts =
 #     script_name = qonnx.module:function

--- a/src/qonnx/util/cleanup.py
+++ b/src/qonnx/util/cleanup.py
@@ -1,0 +1,44 @@
+import clize
+from finn.core.modelwrapper import ModelWrapper
+from finn.transformation.fold_constants import FoldConstants
+from finn.transformation.general import (
+    GiveReadableTensorNames,
+    GiveUniqueNodeNames,
+    GiveUniqueParameterTensors,
+    RemoveStaticGraphInputs,
+    RemoveUnusedTensors,
+)
+from finn.transformation.infer_shapes import InferShapes
+
+
+def cleanup(in_file, *, out_file=None):
+    """Execute a set of graph transformations to clean-up the given ONNX file.
+
+    :param in_file: Filename for the input ONNX model
+    :param out_file: If set, filename for the output ONNX model. Set to in_file with _clean
+        suffix otherwise.
+    """
+
+    model = ModelWrapper(in_file)
+    cleanup_transformations = [
+        InferShapes(),
+        GiveUniqueParameterTensors(),
+        FoldConstants(),
+        RemoveUnusedTensors(),
+        RemoveStaticGraphInputs(),
+        GiveUniqueNodeNames(),
+        GiveReadableTensorNames(),
+    ]
+    for t in cleanup_transformations:
+        model = model.transform(t)
+    if out_file is None:
+        out_file = in_file.replace(".onnx", "_clean.onnx")
+    model.save(out_file)
+
+
+def main():
+    clize.run(cleanup)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/qonnx/util/cleanup.py
+++ b/src/qonnx/util/cleanup.py
@@ -20,6 +20,10 @@ def cleanup(in_file, *, out_file=None):
     """
 
     model = ModelWrapper(in_file)
+    # temporary fix for Quant op domains
+    qnt_nodes = model.get_nodes_by_op_type("Quant")
+    for qnt_node in qnt_nodes:
+        qnt_node.domain = "finn.custom_op.general"
     cleanup_transformations = [
         InferShapes(),
         GiveUniqueParameterTensors(),

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1,0 +1,31 @@
+import os
+import urllib.request
+
+from finn.core.modelwrapper import ModelWrapper
+
+from qonnx.util.cleanup import cleanup
+
+
+def test_cleanup_cnv_w2a2():
+    # download test data
+    dl_dir = "/tmp"
+    dl_file = dl_dir + "/cnv-w2a2.onnx"
+    cnv_w2a2_qonnx_url = "https://drive.google.com/uc?id=1BAyYM3N28fDHSWMgK8dZ3kVUsxGZLO3U&export=download"
+    urllib.request.urlretrieve(cnv_w2a2_qonnx_url, dl_file)
+    assert os.path.isfile(dl_file)
+    # run cleanup with default settings
+    out_file = dl_dir + "/cnv-w2a2-clean.onnx"
+    cleanup(dl_file, out_file=out_file)
+    assert os.path.isfile(out_file)
+    model = ModelWrapper(out_file)
+    # check some names and shapes
+    assert model.check_all_tensor_shapes_specified()
+    assert model.graph.output[0].name == "global_out"
+    assert model.get_tensor_shape(model.graph.output[0].name) == [1, 10]
+    # constant folding should have replaced Shape -> Gather -> Unsqueeze -> Concat -> Reshape
+    # with a Reshape w/ shape=(1,-1)
+    reshape_nodes = model.get_nodes_by_op_type("Reshape")
+    assert len(reshape_nodes) == 1
+    reshape_node = reshape_nodes[0]
+    assert (model.get_initializer(reshape_node.input[1]) == [1, -1]).all()
+    os.remove(dl_file)


### PR DESCRIPTION
Adds a first version of QONNX cleanup (also callable as a command line utility `qonnx-cleanup`) that runs through a set up transformations including shape inference, constant folding and removal of unused tensors and inputs.

Note: this currently introduces a dependency on `finn-base` for quick prototyping and un-blocking the progress on other QONNX projects. The intention is to eventually copy/move the relevant parts into this repo and remove the dependency.