### PR TITLE
README + CITATION update

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,26 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: QONNX
+message: 'If you use this software, please cite it as below.'
+type: software
+authors:
+  - given-names: Yaman
+    family-names: Umuroglu
+    affiliation: AMD
+  - given-names: Hendrik
+    family-names: Borras
+    affiliation: Heidelberg University
+  - given-names: Vladimir
+    family-names: Loncar
+    affiliation: MIT
+    orcid: 'https://orcid.org/0000-0003-3651-0232'
+  - given-names: Sioni
+    family-names: Summers
+    affiliation: CERN
+    orcid: 'https://orcid.org/0000-0003-4244-2061'
+  - given-names: Javier
+    family-names: Duarte
+    affiliation: UC San Diego
+    orcid: 'https://orcid.org/0000-0002-5076-7096'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,6 +14,7 @@ authors:
   - given-names: Yaman
     family-names: Umuroglu
     affiliation: AMD
+    orcid: 'https://orcid.org/ 0000-0002-3700-5935'
   - given-names: Hendrik
     family-names: Borras
     affiliation: Heidelberg University

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,6 +5,11 @@ cff-version: 1.2.0
 title: QONNX
 message: 'If you use this software, please cite it as below.'
 type: software
+doi: 10.5281/zenodo.XXXXXXX
+license: Apache-2.0
+date-released: 2022-XX-XX
+version: X.X.X
+url: "https://github.com/fastmachinelearning/qonnx"
 authors:
   - given-names: Yaman
     family-names: Umuroglu

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 [![ReadTheDocs](https://readthedocs.org/projects/finn-base/badge/?version=latest&style=plastic)](http://finn-base.readthedocs.io/)
 [![GitHub Discussions](https://img.shields.io/github/discussions/fastmachinelearning/qonnx)](https://github.com/fastmachinelearning/qonnx/discussions)
 ![Tests](https://github.com/fastmachinelearning/qonnx/actions/workflows/test.yml/badge.svg)
-
+![Code style](https://img.shields.io/badge/code%20style-black-000000.svg)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.XXXXXXX.svg)](https://doi.org/10.5281/zenodo.XXXXXXX)
 
 <img align="left" src="https://xilinx.github.io/finn/img/TFC_1W2A.onnx.png" alt="QONNX example" style="margin-right: 20px" width="200"/>
 
@@ -141,13 +142,31 @@ The QONNX efforts were started by the FINN and hls4ml communities working togeth
 
 ## Resources
 
-You can read more about QONNX in [this paper](https://arxiv.org/abs/2206.07527). If you find QONNX useful in your work, please consider a citation:
+You can read more about QONNX in [this paper](https://arxiv.org/abs/2206.07527). If you find QONNX useful in your work, please consider citing:
 
 ```
-@article{pappalardo2022qonnx,
-  title={QONNX: Representing Arbitrary-Precision Quantized Neural Networks},
-  author={Pappalardo, Alessandro and Umuroglu, Yaman and Blott, Michaela and Mitrevski, Jovan and Hawks, Ben and Tran, Nhan and Loncar, Vladimir and Summers, Sioni and Borras, Hendrik and Muhizi, Jules and others},
-  journal={arXiv preprint arXiv:2206.07527},
-  year={2022}
+@inproceedings{Pappalardo:2022nxk,
+    author = "Pappalardo, Alessandro and Umuroglu, Yaman and Blott, Michaela and Mitrevski, Jovan and Hawks, Ben and Tran, Nhan and Loncar, Vladimir and Summers, Sioni and Borras, Hendrik and Muhizi, Jules and Trahms, Matthew and Hsu, Shih-Chieh Hsu and Hauck, Scott and Duarte, Javier"
+    title = "{QONNX: Representing Arbitrary-Precision Quantized Neural Networks}",
+    booktitle = "{4th Workshop on Accelerated Machine Learning (AccML) at HiPEAC 2022 Conference}",
+    eprint = "2206.07527",
+    archivePrefix = "arXiv",
+    primaryClass = "cs.LG",
+    reportNumber = "FERMILAB-CONF-22-471-SCD",
+    month = "6",
+    year = "2022",
+    url = "https://accml.dcs.gla.ac.uk/papers/2022/4thAccML_paper_1(12).pdf"
+}
+```
+```
+@software{umuroglu_2022_XXXXXXX,
+  author       = "Umuroglu, Yaman and Borras, Hendrik and Loncar, Vladimir, and Summers, Sioni and Duarte, Javier",
+  title        = "fastmachinelearning/qonnx",
+  month        = {6},
+  year         = 2022,
+  publisher    = {Zenodo},
+  version      = {vX.X.X},
+  doi          = {10.5281/zenodo.XXXXXXX},
+  url          = {https://github.com/fastmachinelearning/qonnx}
 }
 ```


### PR DESCRIPTION
- README + CITATION update

For now, the Zenodo DOI is a dummy (it gets automatically generated once we create a release). If we want we could create a "dummy" release now just so we get the DOI. 

We should probably add a lot more contributors to the `CITATION.cff`.