### PR TITLE
Fix datatype for scalar DivToMul

### DIFF
--- a/src/qonnx/transformation/general.py
+++ b/src/qonnx/transformation/general.py
@@ -255,7 +255,7 @@ class ConvertDivToMul(Transformation):
                 A = model.get_initializer(n.input[1])
                 if A is not None:
                     n.op_type = "Mul"
-                    model.set_initializer(n.input[1], 1.0 / A)
+                    model.set_initializer(n.input[1], (1.0 / A).astype(A.dtype))
         # return model_was_changed = False as single iteration is always enough
         return (model, False)
 


### PR DESCRIPTION
When the parameter to the `Div` node is scalar, the `DivToMul` transformation performs a computation that causes the transformed tensor to change type to `np.float64`. This PR introduces a test case that reproduces this problem and fixes the issue by casting the new tensor's datatype to be the same as the original one's.