### PR TITLE
Keep node names during shape inference to help debug

### DIFF
--- a/src/qonnx/transformation/infer_shapes.py
+++ b/src/qonnx/transformation/infer_shapes.py
@@ -58,6 +58,8 @@ def _hide_finn_ops(model):
         node_ind += 1
         if is_finn_op(node.domain):
             new_node = _make_shape_compatible_op(node, model)
+            # keep old node name to help debug shape inference issues
+            new_node.name = node.name
             hidden_ops[str(new_node)] = node
             model.graph.node.insert(node_ind, new_node)
             model.graph.node.remove(node)


### PR DESCRIPTION
To perform shape inference for custom nodes, we currently replace each custom node with a standard node that produces an output tensor of the desired output shape (as returned by the `make_shape_compatible_op` function). This small PR adds a change that keeps the previous ONNX node name for the newly created node, which can help debug shape inference issues when something fails.