### PR TITLE
Fix MaxPoolNHWC output shape computation

### DIFF
--- a/src/qonnx/custom_op/general/maxpoolnhwc.py
+++ b/src/qonnx/custom_op/general/maxpoolnhwc.py
@@ -70,7 +70,7 @@ class MaxPoolNHWC(CustomOp):
         assert pads[1] == pads[3], "Uneven padding not supported"
         (n, hi, wi, c) = ishape
         ho = compute_pool_output_dim(hi, kernel_shape[0], strides[0], pads[0], ceil_mode)
-        wo = compute_pool_output_dim(wi, kernel_shape[1], strides[1], pads[2], ceil_mode)
+        wo = compute_pool_output_dim(wi, kernel_shape[1], strides[1], pads[1], ceil_mode)
         oshape = (n, ho, wo, c)
         return super().make_const_shape_op(oshape)
 


### PR DESCRIPTION
Previous implementation was using incorrect index from the `pads` attribute for the width dimension. For a 2D maxpool this attribute specifies `(pad_h_start, pad_w_start, pad_h_end, pad_w_end)`