### PR TITLE
Handle convolution bias correctly while lowering

### DIFF
--- a/src/qonnx/transformation/extract_conv_bias.py
+++ b/src/qonnx/transformation/extract_conv_bias.py
@@ -49,10 +49,10 @@ class ExtractBiasFromConv(Transformation):
                     # Extract bias
                     bias = model.get_initializer(n.input[2])
                     if bias is None:
-                        warnings.warn(
-                            f"Could not extract bias from Conv node {n}, " f"due to missing static initialization."
-                        )
-                        continue
+                        bias_prod = model.find_producer(n.input[2])
+                        if bias_prod.op_type != "Quant":
+                            warnings.warn(f"Could not extract bias from Conv node {n}")
+                            continue
 
                     # Insert bias as Add node behind the Conv node
                     out_shape = model.get_tensor_shape(n.output[0])

--- a/src/qonnx/transformation/fold_constants.py
+++ b/src/qonnx/transformation/fold_constants.py
@@ -31,6 +31,43 @@ from qonnx.transformation.base import Transformation
 from qonnx.transformation.infer_shapes import InferShapes
 
 
+class FoldConstantsFiltered(Transformation):
+    """Replace the output of a node with const-only inputs with a precomputed
+    result. Use the match_filter_fxn(model, node) function to decide which nodes
+    can be eligible for const folding."""
+
+    def __init__(self, match_filter_fxn):
+        super().__init__()
+        self.match_filter_fxn = match_filter_fxn
+
+    def apply(self, model):
+        graph = model.graph
+        node_ind = 0
+        graph_modified = False
+        execution_context = model.make_empty_exec_context()
+        for n in graph.node:
+            node_ind += 1
+            node_inp_inits = list(map(lambda x: model.get_initializer(x), n.input))
+            node_inp_dyn = list(filter(lambda x: x is None, node_inp_inits))
+            node_out = n.output[0]
+            is_all_constant_inputs = len(node_inp_dyn) == 0
+            ishape = model.get_tensor_shape(n.input[0])
+            is_const_shape = (n.op_type == "Shape") and (ishape is not None)
+            eligible = self.match_filter_fxn(model, n)
+            if (is_all_constant_inputs or is_const_shape) and eligible:
+                # this node has no dynamic inputs, only constant ones -- so we can
+                # do constant folding.
+                oxe.execute_node(n, execution_context, graph)
+                # use the execution result as an initializer
+                model.set_initializer(node_out, execution_context[node_out])
+                # remove old node
+                graph.node.remove(n)
+                graph_modified = True
+        if graph_modified:
+            model = model.transform(InferShapes())
+        return (model, graph_modified)
+
+
 class FoldConstants(Transformation):
     """Replace the output of a node with const-only inputs with a precomputed
     result. Skip any op types given in exclude_op_types."""


### PR DESCRIPTION
The `LowerConvsToMatMul` transformation previously ignored conv layer biases, resulting in incorrect conversion. This PR tries to extract convolution bias prior to lowering, adds assertions for non-extracted convolution biases, and extends the support in `ExtractConvBias` to quantized biases produced by `Quant`nodes. The `test_dws_reg_conv_lowering` testcase is extended to cover a bias parameter too.