### PR TITLE
Fix channels last conversion for Conv operators with a bias

### DIFF
--- a/src/qonnx/custom_op/channels_last/conv.py
+++ b/src/qonnx/custom_op/channels_last/conv.py
@@ -140,10 +140,10 @@ class Conv(ChannelsLastWrappedOp):
             verification_successful = False
 
         # verify the number of inputs
-        if len(node.input) == 2:
+        if len(node.input) == 2 or len(node.input) == 3:
             info_messages.append("The number of inputs is correct")
         else:
-            info_messages.append("{} needs 2 data inputs".format(node.op_type))
+            info_messages.append("{} needs 2 or 3 data inputs".format(node.op_type))
             verification_successful = False
 
         if not verification_successful:

--- a/src/qonnx/custom_op/channels_last/max_pool.py
+++ b/src/qonnx/custom_op/channels_last/max_pool.py
@@ -94,14 +94,15 @@ class MaxPool(ChannelsLastWrappedOp):
         info_messages.extend(wrapper_info)
 
         # verify number of attributes
-        num_of_attr = 3
-        if len(node.attribute) == num_of_attr:
+        num_of_attr_min = 3
+        num_of_attr_max = 7
+        if (len(node.attribute) >= num_of_attr_min) and len(node.attribute) <= num_of_attr_max:
             info_messages.append("The number of attributes is correct")
         else:
             info_messages.append(
                 """The number of attributes is incorrect,
-            {} should have {} attributes""".format(
-                    node.op_type, num_of_attr
+            {} should have between {} and {} attributes""".format(
+                    node.op_type, num_of_attr_min, num_of_attr_max
                 )
             )
             verification_successful = False

--- a/src/qonnx/transformation/channels_last.py
+++ b/src/qonnx/transformation/channels_last.py
@@ -109,6 +109,9 @@ class InsertChannelsLastDomainsAndTrafos(Transformation):
                     # these don't need a transpose.
                     if n.op_type == "BatchNormalization" and i > 0:
                         continue
+                    # Skip Conv bias since it doesn't need a transpose
+                    if n.op_type == "Conv" and i == 2:
+                        continue
                     # Get the shape of the input tensor
                     # and convert it to the shape for the intermediate tensor
                     chanFirst_shape = model.get_tensor_shape(inp)

--- a/src/qonnx/util/cleanup.py
+++ b/src/qonnx/util/cleanup.py
@@ -2,7 +2,6 @@ import clize
 
 from qonnx.core.modelwrapper import ModelWrapper
 from qonnx.transformation.fold_constants import FoldConstants
-from qonnx.transformation.gemm_to_matmul import GemmToMatMul
 from qonnx.transformation.general import (
     GiveReadableTensorNames,
     GiveUniqueNodeNames,
@@ -31,7 +30,6 @@ def cleanup_model(model):
     cleanup_transformations = [
         InferShapes(),
         GiveUniqueParameterTensors(),
-        GemmToMatMul(),
         FoldConstants(exclude_op_types=["Quant", "BipolarQuant"]),
         FoldTransposeIntoQuantInit(),
         RemoveUnusedTensors(),

--- a/src/qonnx/util/cleanup.py
+++ b/src/qonnx/util/cleanup.py
@@ -2,6 +2,7 @@ import clize
 
 from qonnx.core.modelwrapper import ModelWrapper
 from qonnx.transformation.fold_constants import FoldConstants
+from qonnx.transformation.gemm_to_matmul import GemmToMatMul
 from qonnx.transformation.general import (
     GiveReadableTensorNames,
     GiveUniqueNodeNames,
@@ -30,6 +31,7 @@ def cleanup_model(model):
     cleanup_transformations = [
         InferShapes(),
         GiveUniqueParameterTensors(),
+        GemmToMatMul(),
         FoldConstants(exclude_op_types=["Quant", "BipolarQuant"]),
         FoldTransposeIntoQuantInit(),
         RemoveUnusedTensors(),

--- a/tests/transformation/test_channelslast.py
+++ b/tests/transformation/test_channelslast.py
@@ -51,6 +51,15 @@ model_details = {
         "input_range": (-1, +1),
         "layout_sensitive": True,
     },
+    "Conv_bias_example": {
+        "url": (
+            "https://raw.githubusercontent.com/julesmuhizi/pytorch_hls4ml/7f4459de1d69c1642dd858ff1a970509a61ff017"
+            "/model/CNN/super_resolution.onnx"
+        ),
+        "input_shape": (1, 1, 28, 28),
+        "input_range": (-1, +1),
+        "layout_sensitive": True,
+    },
 }
 
 
@@ -157,7 +166,9 @@ def test_channelslast_conversion_end2end(test_model, make_input_channels_last):
     input_dict = {model.graph.input[0].name: input_tensor}
     output_dict = oxe.execute_onnx(model, input_dict)
     current_result = output_dict[model.graph.output[0].name]
-    assert (golden_result == current_result).all(), "Output of cleaned QONNX model and channels last model should match."
+    assert np.isclose(
+        golden_result, current_result, atol=1e-7
+    ).all(), "Output of cleaned QONNX model and channels last model should match."
     assert model.check_all_tensor_shapes_specified(), "All tensor shapes should be specified."
 
     # Check that the ops, which should be ChannelsLast actually are
@@ -191,8 +202,8 @@ def test_channelslast_conversion_step_by_step(test_model):
     input_dict = {model.graph.input[0].name: input_tensor}
     output_dict = oxe.execute_onnx(model, input_dict)
     current_result = output_dict[model.graph.output[0].name]
-    assert (
-        golden_result == current_result
+    assert np.isclose(
+        golden_result, current_result, atol=1e-7
     ).all(), "Output of cleaned QONNX model and model after applying InsertChannelsLastDomainsAndTrafos should match."
     assert model.check_all_tensor_shapes_specified(), "All tensor shapes should be specified."
 
@@ -202,8 +213,8 @@ def test_channelslast_conversion_step_by_step(test_model):
     input_dict = {model.graph.input[0].name: input_tensor}
     output_dict = oxe.execute_onnx(model, input_dict)
     current_result = output_dict[model.graph.output[0].name]
-    assert (
-        golden_result == current_result
+    assert np.isclose(
+        golden_result, current_result, atol=1e-7
     ).all(), (
         "Output of cleaned QONNX model and model after applying RemoveConsecutiveChanFirstAndChanLastTrafos should match."
     )
@@ -215,8 +226,8 @@ def test_channelslast_conversion_step_by_step(test_model):
     input_dict = {model.graph.input[0].name: input_tensor}
     output_dict = oxe.execute_onnx(model, input_dict)
     current_result = output_dict[model.graph.output[0].name]
-    assert (
-        golden_result == current_result
+    assert np.isclose(
+        golden_result, current_result, atol=1e-7
     ).all(), "Output of cleaned QONNX model and model after applying MoveChanLastUpstream should match."
     assert model.check_all_tensor_shapes_specified(), "All tensor shapes should be specified."
 
@@ -226,8 +237,8 @@ def test_channelslast_conversion_step_by_step(test_model):
     input_dict = {model.graph.input[0].name: input_tensor}
     output_dict = oxe.execute_onnx(model, input_dict)
     current_result = output_dict[model.graph.output[0].name]
-    assert (
-        golden_result == current_result
+    assert np.isclose(
+        golden_result, current_result, atol=1e-7
     ).all(), "Output of cleaned QONNX model and model after applying MoveChanLastUpstream should match."
     assert model.check_all_tensor_shapes_specified(), "All tensor shapes should be specified."
 
@@ -237,8 +248,8 @@ def test_channelslast_conversion_step_by_step(test_model):
     input_dict = {model.graph.input[0].name: input_tensor}
     output_dict = oxe.execute_onnx(model, input_dict)
     current_result = output_dict[model.graph.output[0].name]
-    assert (
-        golden_result == current_result
+    assert np.isclose(
+        golden_result, current_result, atol=1e-7
     ).all(), (
         "Output of cleaned QONNX model and model after applying RemoveConsecutiveChanFirstAndChanLastTrafos should match."
     )
@@ -250,8 +261,8 @@ def test_channelslast_conversion_step_by_step(test_model):
     input_dict = {model.graph.input[0].name: input_tensor}
     output_dict = oxe.execute_onnx(model, input_dict)
     current_result = output_dict[model.graph.output[0].name]
-    assert (
-        golden_result == current_result
+    assert np.isclose(
+        golden_result, current_result, atol=1e-7
     ).all(), "Output of cleaned QONNX model and model after applying MoveChanFirstDownstream should match."
     assert model.check_all_tensor_shapes_specified(), "All tensor shapes should be specified."
 
@@ -262,8 +273,8 @@ def test_channelslast_conversion_step_by_step(test_model):
     input_dict = {model.graph.input[0].name: input_tensor}
     output_dict = oxe.execute_onnx(model, input_dict)
     current_result = output_dict[model.graph.output[0].name]
-    assert (
-        golden_result == current_result
+    assert np.isclose(
+        golden_result, current_result, atol=1e-7
     ).all(), "Output of cleaned QONNX model and model after applying AbsorbChanFirstIntoMatMul should match."
     assert model.check_all_tensor_shapes_specified(), "All tensor shapes should be specified."
 
@@ -276,8 +287,8 @@ def test_channelslast_conversion_step_by_step(test_model):
     input_dict = {model.graph.input[0].name: input_tensor}
     output_dict = oxe.execute_onnx(model, input_dict)
     current_result = output_dict[model.graph.output[0].name]
-    assert (
-        golden_result == current_result
+    assert np.isclose(
+        golden_result, current_result, atol=1e-7
     ).all(), "Output of cleaned QONNX model and model after applying AbsorbChanFirstIntoMatMul should match."
     assert model.check_all_tensor_shapes_specified(), "All tensor shapes should be specified."
 


### PR DESCRIPTION
As reported in #32, the channels-last conversion currently fails for Conv operators with a bias and gives:

```
AssertionError: Channels last conversion is only available for 3D and 4D tensors.
```

This attempts to solve the problem by simply skipping over the bias tensor for Conv operators.
