### PR TITLE
Typecast ints attributes to list for better behavior

### DIFF
--- a/src/qonnx/custom_op/base.py
+++ b/src/qonnx/custom_op/base.py
@@ -76,6 +76,10 @@ class CustomOp(ABC):
                 elif dtype == "t":
                     # use numpy helper to convert TensorProto -> np array
                     ret = np_helper.to_array(ret)
+                elif dtype == "ints":
+                    # convert from RepeatedScalarContainer to list
+                    # gives e.g. JSON serializability
+                    ret = [x for x in ret]
                 if allowed_values is not None:
                     assert ret in allowed_values, "%s = %s not in %s" % (
                         str(name),

--- a/src/qonnx/custom_op/channels_last/conv.py
+++ b/src/qonnx/custom_op/channels_last/conv.py
@@ -1,5 +1,4 @@
 import numpy as np
-from google.protobuf.pyext._message import RepeatedScalarContainer
 from onnx import TensorProto, helper
 
 from qonnx.custom_op.channels_last.base_wrapped_op import ChannelsLastWrappedOp
@@ -129,10 +128,10 @@ class Conv(ChannelsLastWrappedOp):
 
         # verify that attributes have the correct datatype.
         try:
-            assert isinstance(self.get_nodeattr("kernel_shape"), RepeatedScalarContainer)
-            assert isinstance(self.get_nodeattr("pads"), RepeatedScalarContainer)
-            assert isinstance(self.get_nodeattr("strides"), RepeatedScalarContainer)
-            assert isinstance(self.get_nodeattr("dilations"), RepeatedScalarContainer)
+            assert isinstance(self.get_nodeattr("kernel_shape"), list)
+            assert isinstance(self.get_nodeattr("pads"), list)
+            assert isinstance(self.get_nodeattr("strides"), list)
+            assert isinstance(self.get_nodeattr("dilations"), list)
             assert isinstance(self.get_nodeattr("group"), int)
             info_messages.append("All attributes are of the correct type")
         except Exception:

--- a/src/qonnx/custom_op/channels_last/max_pool.py
+++ b/src/qonnx/custom_op/channels_last/max_pool.py
@@ -1,5 +1,4 @@
 import numpy as np
-from google.protobuf.pyext._message import RepeatedScalarContainer
 from onnx import TensorProto, helper
 
 from qonnx.custom_op.channels_last.base_wrapped_op import ChannelsLastWrappedOp
@@ -122,9 +121,9 @@ class MaxPool(ChannelsLastWrappedOp):
 
         # verify that attributes have the correct datatype.
         try:
-            assert isinstance(self.get_nodeattr("kernel_shape"), RepeatedScalarContainer)
-            assert isinstance(self.get_nodeattr("pads"), RepeatedScalarContainer)
-            assert isinstance(self.get_nodeattr("strides"), RepeatedScalarContainer)
+            assert isinstance(self.get_nodeattr("kernel_shape"), list)
+            assert isinstance(self.get_nodeattr("pads"), list)
+            assert isinstance(self.get_nodeattr("strides"), list)
             info_messages.append("All attributes are of the correct type")
         except Exception:
             info_messages.append("One or more attributes are of the wrong datatype")


### PR DESCRIPTION
For `CustomOp` instances that use an attribute of ONNX dtype `ints`, convert to a regular Python list as part of the getter since the underlying protobuf `RepeatedScalarContainer` causes e.g. JSON serialization issues.