### PR TITLE
Update onnx and protobuf versions

### DIFF
--- a/notebooks/0_how_to_work_with_onnx.ipynb
+++ b/notebooks/0_how_to_work_with_onnx.ipynb
@@ -31,11 +31,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "import onnx\n",
+    "from qonnx.basic.util import qonnx_make_model\n",
     "\n",
     "Add1_node = onnx.helper.make_node(\n",
     "    'Add',\n",
@@ -56,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -98,7 +99,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -119,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -154,11 +155,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "onnx_model = onnx.helper.make_model(graph, producer_name=\"simple-model\")\n",
+    "onnx_model = qonnx_make_model(graph, producer_name=\"simple-model\")\n",
     "onnx.save(onnx_model, '/tmp/simple_model.onnx')"
    ]
   },
@@ -171,7 +172,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -207,39 +208,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Serving '/tmp/simple_model.onnx' at http://0.0.0.0:8081\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "        <iframe\n",
-       "            width=\"100%\"\n",
-       "            height=\"400\"\n",
-       "            src=\"http://localhost:8081/\"\n",
-       "            frameborder=\"0\"\n",
-       "            allowfullscreen\n",
-       "            \n",
-       "        ></iframe>\n",
-       "        "
-      ],
-      "text/plain": [
-       "<IPython.lib.display.IFrame at 0x7f3767956450>"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "showInNetron('/tmp/simple_model.onnx')"
    ]
@@ -255,7 +226,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -278,7 +249,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -296,7 +267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -315,7 +286,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -334,29 +305,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The output of the ONNX model is: \n",
-      "[[ 3. 23.  5.  2.]\n",
-      " [ 2. 11. 13. 19.]\n",
-      " [17.  1.  5. 12.]\n",
-      " [ 4. 19.  5. 12.]]\n",
-      "\n",
-      "The output of the reference function is: \n",
-      "[[ 3. 23.  5.  2.]\n",
-      " [ 2. 11. 13. 19.]\n",
-      " [17.  1.  5. 12.]\n",
-      " [ 4. 19.  5. 12.]]\n",
-      "\n",
-      "The results are the same!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "ref_output= expected_output(in1_values, in2_values, in3_values)\n",
     "print(\"The output of the ONNX model is: \\n{}\".format(output[0]))\n",
@@ -395,7 +346,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -412,7 +363,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -436,7 +387,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -459,19 +410,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Found adder node: Add1\n",
-      "Found adder node: Add2\n",
-      "Found adder node: Add3\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "add_nodes = identify_adder_nodes(finn_model)\n",
     "for node in add_nodes:\n",
@@ -487,7 +428,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -516,7 +457,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -546,19 +487,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Found following pair that could be replaced by a sum node:\n",
-      "Add1\n",
-      "Add2\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "for node in add_nodes:\n",
     "    add_pairs = adder_pair(finn_model, node)\n",
@@ -582,18 +513,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The new node gets the following inputs: \n",
-      "['in1', 'in2', 'in3']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "input_list = []\n",
     "for i in range(len(substitute_pair)):\n",
@@ -617,7 +539,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -633,7 +555,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -654,7 +576,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -682,50 +604,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "onnx_model1 = onnx.helper.make_model(graph, producer_name=\"simple-model1\")\n",
+    "onnx_model1 = onnx.qonnx_make_model(graph, producer_name=\"simple-model1\")\n",
     "onnx.save(onnx_model1, '/tmp/simple_model1.onnx')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Stopping http://0.0.0.0:8081\n",
-      "Serving '/tmp/simple_model1.onnx' at http://0.0.0.0:8081\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "        <iframe\n",
-       "            width=\"100%\"\n",
-       "            height=\"400\"\n",
-       "            src=\"http://localhost:8081/\"\n",
-       "            frameborder=\"0\"\n",
-       "            allowfullscreen\n",
-       "            \n",
-       "        ></iframe>\n",
-       "        "
-      ],
-      "text/plain": [
-       "<IPython.lib.display.IFrame at 0x7f3767956590>"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "showInNetron('/tmp/simple_model1.onnx')"
    ]
@@ -739,7 +630,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -749,29 +640,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The output of the manipulated ONNX model is: \n",
-      "[[ 3. 23.  5.  2.]\n",
-      " [ 2. 11. 13. 19.]\n",
-      " [17.  1.  5. 12.]\n",
-      " [ 4. 19.  5. 12.]]\n",
-      "\n",
-      "The output of the reference function is: \n",
-      "[[ 3. 23.  5.  2.]\n",
-      " [ 2. 11. 13. 19.]\n",
-      " [17.  1.  5. 12.]\n",
-      " [ 4. 19.  5. 12.]]\n",
-      "\n",
-      "The results are the same!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"The output of the manipulated ONNX model is: \\n{}\".format(output[0]))\n",
     "print(\"\\nThe output of the reference function is: \\n{}\".format(ref_output))\n",
@@ -785,7 +656,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "venv",
    "language": "python",
    "name": "python3"
   },
@@ -799,7 +670,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.8.16"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "0502196cae5450340bff0232db0d443756691d3235661ea220d02e5c6b2dd97d"
+   }
   }
  },
  "nbformat": 4,

--- a/notebooks/1_custom_analysis_pass.ipynb
+++ b/notebooks/1_custom_analysis_pass.ipynb
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,39 +87,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Serving 'TFC_2W2A.onnx' at http://0.0.0.0:8081\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "        <iframe\n",
-       "            width=\"100%\"\n",
-       "            height=\"400\"\n",
-       "            src=\"http://localhost:8081/\"\n",
-       "            frameborder=\"0\"\n",
-       "            allowfullscreen\n",
-       "            \n",
-       "        ></iframe>\n",
-       "        "
-      ],
-      "text/plain": [
-       "<IPython.lib.display.IFrame at 0x7f5c746cf490>"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "download_model_from_zoo()\n",
     "showInNetron(\"TFC_2W2A.onnx\")"
@@ -134,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -151,7 +121,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -181,20 +151,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    def analysis(self, analysis_fxn):\n",
-      "        \"\"\"Runs given anaylsis_fxn on this model and return resulting dict.\"\"\"\n",
-      "        return analysis_fxn(self)\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "showSrc(ModelWrapper.analysis)"
    ]
@@ -208,17 +167,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'Shape': 1, 'Gather': 1, 'Unsqueeze': 1, 'Concat': 1, 'Reshape': 1, 'Mul': 2, 'Sub': 2, 'Quant': 8, 'Transpose': 4, 'MatMul': 4, 'BatchNormalization': 3, 'Pow': 1, 'Div': 1, 'Add': 1}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(model.analysis(count_unique_node_types))"
    ]
@@ -233,7 +184,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "venv",
    "language": "python",
    "name": "python3"
   },
@@ -247,7 +198,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.8.16 (default, Dec  7 2022, 01:12:06) \n[GCC 11.3.0]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "0502196cae5450340bff0232db0d443756691d3235661ea220d02e5c6b2dd97d"
+   }
   }
  },
  "nbformat": 4,

--- a/notebooks/2_custom_transformation_pass.ipynb
+++ b/notebooks/2_custom_transformation_pass.ipynb
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -81,35 +81,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    def transform(self, transformation, make_deepcopy=True, cleanup=True):\n",
-      "        \"\"\"Applies given Transformation repeatedly until no more changes can be made\n",
-      "        and returns a transformed ModelWrapper instance.\n",
-      "\n",
-      "        - make_deepcopy : operates on a new (deep)copy of model.\n",
-      "        - cleanup : execute cleanup transformations before returning\n",
-      "        \"\"\"\n",
-      "        transformed_model = self\n",
-      "        if make_deepcopy:\n",
-      "            transformed_model = copy.deepcopy(self)\n",
-      "        if self.fix_float64:\n",
-      "            (transformed_model, model_was_changed) = DoubleToSingleFloat().apply(transformed_model)\n",
-      "        model_was_changed = True\n",
-      "        while model_was_changed:\n",
-      "            (transformed_model, model_was_changed) = transformation.apply(transformed_model)\n",
-      "        if cleanup:\n",
-      "            transformed_model.cleanup()\n",
-      "        return transformed_model\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from qonnx.core.modelwrapper import ModelWrapper\n",
     "showSrc(ModelWrapper.transform)"
@@ -140,27 +114,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "class Transformation(ABC):\n",
-      "    \"\"\"Transformation class all transformations are based on. Contains only\n",
-      "    abstract method apply() every transformation has to fill.\"\"\"\n",
-      "\n",
-      "    def __init__(self):\n",
-      "        super().__init__()\n",
-      "\n",
-      "    @abstractmethod\n",
-      "    def apply(self, model):\n",
-      "        pass\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from qonnx.transformation.base import Transformation\n",
     "\n",
@@ -187,7 +143,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -200,46 +156,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Serving 'TFC_2W2A.onnx' at http://0.0.0.0:8081\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "        <iframe\n",
-       "            width=\"100%\"\n",
-       "            height=\"400\"\n",
-       "            src=\"http://localhost:8081/\"\n",
-       "            frameborder=\"0\"\n",
-       "            allowfullscreen\n",
-       "            \n",
-       "        ></iframe>\n",
-       "        "
-      ],
-      "text/plain": [
-       "<IPython.lib.display.IFrame at 0x7fca954c9050>"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "showInNetron(\"TFC_2W2A.onnx\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -276,7 +202,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -286,40 +212,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Stopping http://0.0.0.0:8081\n",
-      "Serving '/tmp/LFCW1A1_changed.onnx' at http://0.0.0.0:8081\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "        <iframe\n",
-       "            width=\"100%\"\n",
-       "            height=\"400\"\n",
-       "            src=\"http://localhost:8081/\"\n",
-       "            frameborder=\"0\"\n",
-       "            allowfullscreen\n",
-       "            \n",
-       "        ></iframe>\n",
-       "        "
-      ],
-      "text/plain": [
-       "<IPython.lib.display.IFrame at 0x7fca948a9510>"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "showInNetron('/tmp/LFCW1A1_changed.onnx')"
    ]
@@ -335,66 +230,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "class NodeLocalTransformation(Transformation):\n",
-      "    \"\"\"\n",
-      "    Parent class for transformations, which can be executed locally to one node\n",
-      "    by accessing and modifying the attributes of only that node.\n",
-      "    This class can then automatically parallelize the transformation.\n",
-      "    Transformations sublcassing NodeLocalTransformation must implement the\n",
-      "    abstract method applyNodeLocal().\n",
-      "\n",
-      "    To control the degree of parallelization, specify the num_workers argument\n",
-      "    in the constructor, using one of the following values:\n",
-      "    * None: use NUM_DEFAULT_WORKERS environment variable\n",
-      "    * 0: use all available CPU cores\n",
-      "    * (any other int>0): set number of parallel workers\n",
-      "    \"\"\"\n",
-      "\n",
-      "    def __init__(self, num_workers=None):\n",
-      "        super().__init__()\n",
-      "        if num_workers is None:\n",
-      "            self._num_workers = get_num_default_workers()\n",
-      "        else:\n",
-      "            self._num_workers = num_workers\n",
-      "        assert self._num_workers >= 0, \"Number of workers must be nonnegative.\"\n",
-      "        if self._num_workers == 0:\n",
-      "            self._num_workers = mp.cpu_count()\n",
-      "\n",
-      "    @abstractmethod\n",
-      "    def applyNodeLocal(self, node):\n",
-      "        pass\n",
-      "\n",
-      "    def apply(self, model):\n",
-      "        # Remove old nodes from the current model\n",
-      "        old_nodes = []\n",
-      "        for i in range(len(model.graph.node)):\n",
-      "            old_nodes.append(model.graph.node.pop())\n",
-      "\n",
-      "        # Execute transformation in parallel\n",
-      "        with mp.Pool(self._num_workers) as p:\n",
-      "            new_nodes_and_bool = p.map(self.applyNodeLocal, old_nodes, chunksize=1)\n",
-      "\n",
-      "        # extract nodes and check if the transformation needs to run again\n",
-      "        # Note: .pop() had initially reversed the node order\n",
-      "        run_again = False\n",
-      "        for node, run in reversed(new_nodes_and_bool):\n",
-      "            # Reattach new nodes to old model\n",
-      "            model.graph.node.append(node)\n",
-      "            if run is True:\n",
-      "                run_again = True\n",
-      "\n",
-      "        return (model, run_again)\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from qonnx.transformation.base import NodeLocalTransformation\n",
     "\n",
@@ -420,7 +258,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "venv",
    "language": "python",
    "name": "python3"
   },
@@ -434,7 +272,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.8.16 (default, Dec  7 2022, 01:12:06) \n[GCC 11.3.0]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "0502196cae5450340bff0232db0d443756691d3235661ea220d02e5c6b2dd97d"
+   }
   }
  },
  "nbformat": 4,

--- a/notebooks/3_custom_op.ipynb
+++ b/notebooks/3_custom_op.ipynb
@@ -28,58 +28,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['__abstractmethods__',\n",
-       " '__class__',\n",
-       " '__delattr__',\n",
-       " '__dict__',\n",
-       " '__dir__',\n",
-       " '__doc__',\n",
-       " '__eq__',\n",
-       " '__format__',\n",
-       " '__ge__',\n",
-       " '__getattribute__',\n",
-       " '__gt__',\n",
-       " '__hash__',\n",
-       " '__init__',\n",
-       " '__init_subclass__',\n",
-       " '__le__',\n",
-       " '__lt__',\n",
-       " '__module__',\n",
-       " '__ne__',\n",
-       " '__new__',\n",
-       " '__reduce__',\n",
-       " '__reduce_ex__',\n",
-       " '__repr__',\n",
-       " '__setattr__',\n",
-       " '__sizeof__',\n",
-       " '__slots__',\n",
-       " '__str__',\n",
-       " '__subclasshook__',\n",
-       " '__weakref__',\n",
-       " '_abc_impl',\n",
-       " 'execute_node',\n",
-       " 'get_nodeattr',\n",
-       " 'get_nodeattr_allowed_values',\n",
-       " 'get_nodeattr_def',\n",
-       " 'get_nodeattr_types',\n",
-       " 'infer_node_datatype',\n",
-       " 'make_const_shape_op',\n",
-       " 'make_shape_compatible_op',\n",
-       " 'set_nodeattr',\n",
-       " 'verify_node']"
-      ]
-     },
-     "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from qonnx.custom_op.base import CustomOp\n",
     "dir(CustomOp)"
@@ -96,7 +47,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -184,7 +135,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -201,30 +152,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'DebugMarker': qonnx.custom_op.general.debugmarker.DebugMarker,\n",
-       " 'QuantAvgPool2d': qonnx.custom_op.general.quantavgpool2d.QuantAvgPool2d,\n",
-       " 'MaxPoolNHWC': qonnx.custom_op.general.maxpoolnhwc.MaxPoolNHWC,\n",
-       " 'GenericPartition': qonnx.custom_op.general.genericpartition.GenericPartition,\n",
-       " 'MultiThreshold': qonnx.custom_op.general.multithreshold.MultiThreshold,\n",
-       " 'XnorPopcountMatMul': qonnx.custom_op.general.xnorpopcount.XnorPopcountMatMul,\n",
-       " 'Im2Col': qonnx.custom_op.general.im2col.Im2Col,\n",
-       " 'Quant': qonnx.custom_op.general.quant.Quant,\n",
-       " 'Trunc': qonnx.custom_op.general.trunc.Trunc,\n",
-       " 'BipolarQuant': qonnx.custom_op.general.bipolar_quant.BipolarQuant,\n",
-       " 'MyPythonPowerOp': __main__.MyPythonPowerOp}"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "general.custom_op"
    ]
@@ -242,12 +172,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "from qonnx.core.modelwrapper import ModelWrapper\n",
     "from onnx import TensorProto\n",
+    "from qonnx.util.basic import qonnx_make_model\n",
     "\n",
     "def make_graph(ishape, exp, op_type = \"MyPythonPowerOp\"):\n",
     "    inp = helper.make_tensor_value_info(\n",
@@ -274,7 +205,7 @@
     "    graph = helper.make_graph(\n",
     "        nodes=[custom_node], name=\"custom_graph\", inputs=[inp], outputs=[outp]\n",
     "    )\n",
-    "    model = helper.make_model(graph, producer_name=\"custom-model\")\n",
+    "    model = qonnx_make_model(graph, producer_name=\"custom-model\")\n",
     "    return ModelWrapper(model)"
    ]
   },
@@ -287,34 +218,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[input: \"inp\"\n",
-       "output: \"outp\"\n",
-       "op_type: \"MyPythonPowerOp\"\n",
-       "attribute {\n",
-       "  name: \"exec_mode\"\n",
-       "  s: \"python\"\n",
-       "  type: STRING\n",
-       "}\n",
-       "attribute {\n",
-       "  name: \"exponent\"\n",
-       "  i: 2\n",
-       "  type: INT\n",
-       "}\n",
-       "domain: \"qonnx.custom_op.general\"\n",
-       "]"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# generate a small graph with our custom op\n",
     "input_shape = (1, 2, 4)\n",
@@ -331,21 +237,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([[[-3., -4., -6.,  5.],\n",
-       "        [-7., -5.,  5.,  2.]]], dtype=float32)"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from qonnx.core.datatype import DataType\n",
     "from qonnx.util.basic import gen_finn_dt_tensor\n",
@@ -364,21 +258,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'outp': array([[[ 9., 16., 36., 25.],\n",
-       "         [49., 25., 25.,  4.]]], dtype=float32)}"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from qonnx.core.onnx_exec import execute_onnx\n",
     "\n",
@@ -410,7 +292,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -466,7 +348,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -580,34 +462,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[input: \"inp\"\n",
-       "output: \"outp\"\n",
-       "op_type: \"MyMixedPowerOp\"\n",
-       "attribute {\n",
-       "  name: \"exec_mode\"\n",
-       "  s: \"python\"\n",
-       "  type: STRING\n",
-       "}\n",
-       "attribute {\n",
-       "  name: \"exponent\"\n",
-       "  i: 2\n",
-       "  type: INT\n",
-       "}\n",
-       "domain: \"qonnx.custom_op.general\"\n",
-       "]"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# register our new op\n",
     "general.custom_op[\"MyMixedPowerOp\"] = MyMixedPowerOp\n",
@@ -626,19 +483,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Available functions: ['__abstractmethods__', '__class__', '__delattr__', '__dict__', '__dir__', '__doc__', '__eq__', '__format__', '__ge__', '__getattribute__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__slots__', '__str__', '__subclasshook__', '__weakref__', '_abc_impl', 'execute_node', 'get_nodeattr', 'get_nodeattr_allowed_values', 'get_nodeattr_def', 'get_nodeattr_types', 'infer_node_datatype', 'make_const_shape_op', 'make_shape_compatible_op', 'my_custom_cpp_gen', 'onnx_node', 'set_nodeattr', 'verify_node']\n",
-      "codegen_dir: \n",
-      "exec_mode: python\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from qonnx.custom_op.registry import getCustomOp\n",
     "\n",
@@ -661,7 +508,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -700,7 +547,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -716,17 +563,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "/tmp/my_custom_opaidy0_w7\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "new_op_inst = getCustomOp(mixedop_graph_new.graph.node[0])\n",
     "codegen_dir = new_op_inst.get_nodeattr(\"codegen_dir\")\n",
@@ -742,17 +581,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "compile.sh  node_model\ttop.cpp\r\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "! ls {codegen_dir}"
    ]
@@ -766,39 +597,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "#include <iostream>\r\n",
-      "#include <fstream>\r\n",
-      "using namespace std;\r\n",
-      "#define EXPONENT 2\r\n",
-      "\r\n",
-      "int main(int argc, char **argv) {\r\n",
-      "    ifstream infile(\"input.txt\");\r\n",
-      "    ofstream outfile(\"output.txt\");\r\n",
-      "    \r\n",
-      "    float elem;\r\n",
-      "    while (infile >> elem)\r\n",
-      "    {\r\n",
-      "        float res = 1.0;\r\n",
-      "        for(int i=0; i < EXPONENT; i++) {\r\n",
-      "            res *= elem;\r\n",
-      "        }\r\n",
-      "        outfile << res << \"\\n\";\r\n",
-      "    }\r\n",
-      "\r\n",
-      "    return 0;\r\n",
-      "}\r\n",
-      "        "
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "! cat {codegen_dir}/top.cpp"
    ]
@@ -816,7 +617,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -825,7 +626,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -834,26 +635,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "49\r\n",
-      "64\r\n",
-      "81\r\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "! cat {codegen_dir}/output.txt"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -871,21 +662,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([[[ 5.,  2.,  5., -5.],\n",
-       "        [-2., -1., -3.,  7.]]], dtype=float32)"
-      ]
-     },
-     "execution_count": 28,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# generate a random input of e.g signed 4-bit values\n",
     "random_input = gen_finn_dt_tensor(DataType[\"INT4\"], input_shape)\n",
@@ -901,21 +680,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'outp': array([[[25.,  4., 25., 25.],\n",
-       "         [ 4.,  1.,  9., 49.]]], dtype=float32)}"
-      ]
-     },
-     "execution_count": 29,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# run with QONNX's execute_onnx, custom node will use Python execution\n",
     "new_op_inst.set_nodeattr(\"exec_mode\", \"python\")\n",
@@ -933,21 +700,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'outp': array([[[25.,  4., 25., 25.],\n",
-       "         [ 4.,  1.,  9., 49.]]])}"
-      ]
-     },
-     "execution_count": 30,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# run with QONNX's execute_onnx, custom node will use c++ execution\n",
     "new_op_inst.set_nodeattr(\"exec_mode\", \"c++\")\n",
@@ -965,7 +720,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "venv",
    "language": "python",
    "name": "python3"
   },
@@ -979,7 +734,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.8.16 (default, Dec  7 2022, 01:12:06) \n[GCC 11.3.0]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "0502196cae5450340bff0232db0d443756691d3235661ea220d02e5c6b2dd97d"
+   }
   }
  },
  "nbformat": 4,

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,10 +46,10 @@ package_dir =
 install_requires =
     importlib-metadata; python_version<"3.8"
     clize==4.1.1
-    protobuf==3.20.1
+    protobuf==3.20.3
     bitstring>=3.1.7
     numpy==1.24.1
-    onnx==1.11.0
+    onnx==1.13.0
     onnxruntime==1.11.1
     sigtools==2.0.3
     toposort==1.7.0

--- a/src/qonnx/core/onnx_exec.py
+++ b/src/qonnx/core/onnx_exec.py
@@ -34,7 +34,7 @@ import onnxruntime as rt
 
 import qonnx.analysis.topology as ta
 import qonnx.core.execute_custom_node as ex_cu_node
-from qonnx.util.basic import get_sanitize_quant_tensors, is_finn_op, sanitize_quant_values
+from qonnx.util.basic import get_sanitize_quant_tensors, is_finn_op, qonnx_make_model, sanitize_quant_values
 
 
 def execute_node(node, context, graph, return_full_exec_context=False, opset_version=9):
@@ -64,7 +64,7 @@ def execute_node(node, context, graph, return_full_exec_context=False, opset_ver
             inputs=node_inputs,
             outputs=node_outputs,
         )
-        node_model = helper.make_model(node_graph)
+        node_model = qonnx_make_model(node_graph)
         node_model.opset_import[0].version = opset_version
         input_dict = dict()
         for inp in node.input:

--- a/src/qonnx/custom_op/channels_last/base_wrapped_op.py
+++ b/src/qonnx/custom_op/channels_last/base_wrapped_op.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 from onnx import TensorProto, helper
 
 from qonnx.custom_op.base import CustomOp
+from qonnx.util.basic import qonnx_make_model
 
 
 def to_channels_last_args(ndim):
@@ -96,7 +97,7 @@ class ChannelsLastWrappedOp(CustomOp):
         # Execute the intermediate node with onnxruntime,
         # using the transposed inputs / outputs
         intermediate_graph = helper.make_graph([intermediate_node], "test_model", input_tensor_list, output_tensor_list)
-        intermediate_model = helper.make_model(intermediate_graph)
+        intermediate_model = qonnx_make_model(intermediate_graph)
         sess = rt.InferenceSession(intermediate_model.SerializeToString())
         output_list = sess.run(None, input_dict)
         output_onnx = output_list[0]

--- a/src/qonnx/custom_op/general/maxpoolnhwc.py
+++ b/src/qonnx/custom_op/general/maxpoolnhwc.py
@@ -33,6 +33,7 @@ from onnx import TensorProto, helper
 
 from qonnx.core.modelwrapper import ModelWrapper
 from qonnx.custom_op.base import CustomOp
+from qonnx.util.basic import qonnx_make_model
 
 
 def compute_pool_output_dim(ifm_dim, k, stride, pad=0, ceil_mode=0):
@@ -96,7 +97,7 @@ class MaxPoolNHWC(CustomOp):
         inp_vi = helper.make_tensor_value_info(inp_name, TensorProto.FLOAT, inp.shape)
         out_vi = helper.make_tensor_value_info(out_name, TensorProto.FLOAT, dummy_out.shape)
         tmp_graph = helper.make_graph(nodes=[node], name="tmp_graph", inputs=[inp_vi], outputs=[out_vi])
-        tmp_model = helper.make_model(tmp_graph, producer_name="finn")
+        tmp_model = qonnx_make_model(tmp_graph, producer_name="finn")
         tmp_model = ModelWrapper(tmp_model)
         new_ctx = {inp_name: inp}
         from qonnx.core.onnx_exec import execute_onnx

--- a/src/qonnx/custom_op/general/quantavgpool2d.py
+++ b/src/qonnx/custom_op/general/quantavgpool2d.py
@@ -33,6 +33,7 @@ from onnx import TensorProto, helper
 from qonnx.core.datatype import DataType
 from qonnx.custom_op.base import CustomOp
 from qonnx.custom_op.general.maxpoolnhwc import compute_pool_output_dim
+from qonnx.util.basic import qonnx_make_model
 
 
 class QuantAvgPool2d(CustomOp):
@@ -130,7 +131,7 @@ class QuantAvgPool2d(CustomOp):
             inputs=[inp],
             outputs=[outp],
         )
-        model_avgpool = helper.make_model(graph_avgpool)
+        model_avgpool = qonnx_make_model(graph_avgpool)
         idict = {node.input[0]: inp_values}
         sess = rt.InferenceSession(model_avgpool.SerializeToString())
         result_temp = sess.run(None, idict)

--- a/src/qonnx/transformation/merge_onnx_models.py
+++ b/src/qonnx/transformation/merge_onnx_models.py
@@ -40,6 +40,7 @@ from qonnx.transformation.general import (
 from qonnx.transformation.infer_data_layouts import InferDataLayouts
 from qonnx.transformation.infer_datatypes import InferDataTypes
 from qonnx.transformation.infer_shapes import InferShapes
+from qonnx.util.basic import qonnx_make_model
 
 
 class MergeONNXModels(Transformation):
@@ -142,7 +143,7 @@ class MergeONNXModels(Transformation):
             value_info=vi_new,
         )
 
-        new_model = helper.make_model(new_graph, producer_name="fuse_model")
+        new_model = qonnx_make_model(new_graph, producer_name="fuse_model")
         new_model = ModelWrapper(new_model)
 
         for i in init_new:

--- a/src/qonnx/util/basic.py
+++ b/src/qonnx/util/basic.py
@@ -31,8 +31,25 @@ import os
 import random
 import string
 import warnings
+from onnx.helper import make_model, make_opsetid
 
 from qonnx.core.datatype import DataType
+
+
+def get_preferred_onnx_opset():
+    "Return preferred ONNX opset version for QONNX"
+    return 9
+
+
+def qonnx_make_model(graph_proto, **kwargs):
+    "Wrapper around ONNX make_model with preferred qonnx opset version"
+    opset_imports = kwargs.pop("opset_imports", None)
+    if opset_imports is None:
+        opset_imports = [make_opsetid("", get_preferred_onnx_opset())]
+        kwargs["opset_imports"] = opset_imports
+    else:
+        kwargs["opset_imports"] = opset_imports
+    return make_model(graph_proto, **kwargs)
 
 
 def is_finn_op(op_type):

--- a/tests/analysis/test_is_linear.py
+++ b/tests/analysis/test_is_linear.py
@@ -32,6 +32,7 @@ from onnx import TensorProto
 import qonnx.analysis.topology as ta
 from qonnx.core.modelwrapper import ModelWrapper
 from qonnx.transformation.infer_shapes import InferShapes
+from qonnx.util.basic import qonnx_make_model
 
 
 def test_is_linear_linear():
@@ -39,7 +40,7 @@ def test_is_linear_linear():
     add_param = oh.make_tensor_value_info("add_param", TensorProto.FLOAT, [2])
     mul_param = oh.make_tensor_value_info("mul_param", TensorProto.FLOAT, [2])
     top_out = oh.make_tensor_value_info("top_out", TensorProto.FLOAT, [2])
-    modelproto = oh.make_model(
+    modelproto = qonnx_make_model(
         oh.make_graph(
             name="test",
             inputs=[top_in],
@@ -65,7 +66,7 @@ def test_is_linear_forked_node_output():
     mul0_res = oh.make_tensor_value_info("mul0_res", TensorProto.FLOAT, [2])
     mul1_res = oh.make_tensor_value_info("mul1_res", TensorProto.FLOAT, [2])
     top_out = oh.make_tensor_value_info("top_out", TensorProto.FLOAT, [2])
-    modelproto = oh.make_model(
+    modelproto = qonnx_make_model(
         oh.make_graph(
             name="test",
             inputs=[top_in],

--- a/tests/analysis/test_topology_checks.py
+++ b/tests/analysis/test_topology_checks.py
@@ -33,6 +33,7 @@ from pkgutil import get_data
 import qonnx.analysis.topology as ta
 from qonnx.core.modelwrapper import ModelWrapper
 from qonnx.transformation.infer_shapes import InferShapes
+from qonnx.util.basic import qonnx_make_model
 
 
 def test_all_tensors_f32():
@@ -40,7 +41,7 @@ def test_all_tensors_f32():
     add_param = oh.make_tensor_value_info("add_param", TensorProto.FLOAT, [2])
     mul_param = oh.make_tensor_value_info("mul_param", TensorProto.FLOAT, [2])
     top_out = oh.make_tensor_value_info("top_out", TensorProto.FLOAT, [2])
-    modelproto = oh.make_model(
+    modelproto = qonnx_make_model(
         oh.make_graph(
             name="test",
             inputs=[top_in],
@@ -61,7 +62,7 @@ def test_all_tensors_f32():
     add_param = oh.make_tensor_value_info("add_param", TensorProto.INT8, [2])
     mul_param = oh.make_tensor_value_info("mul_param", TensorProto.FLOAT, [2])
     top_out = oh.make_tensor_value_info("top_out", TensorProto.FLOAT, [2])
-    modelproto = oh.make_model(
+    modelproto = qonnx_make_model(
         oh.make_graph(
             name="test",
             inputs=[top_in],
@@ -127,7 +128,7 @@ def test_nodes_topologically_sorted():
         ],
     )
 
-    onnx_model = oh.make_model(graph, producer_name="simple-model")
+    onnx_model = qonnx_make_model(graph, producer_name="simple-model")
     model = ModelWrapper(onnx_model)
 
     ret = model.analysis(ta.nodes_topologically_sorted)
@@ -146,7 +147,7 @@ def test_nodes_topologically_sorted():
         ],
     )
 
-    onnx_model = oh.make_model(graph, producer_name="simple-model")
+    onnx_model = qonnx_make_model(graph, producer_name="simple-model")
     model = ModelWrapper(onnx_model)
 
     ret = model.analysis(ta.nodes_topologically_sorted)

--- a/tests/core/test_basic_onnx_exec.py
+++ b/tests/core/test_basic_onnx_exec.py
@@ -35,7 +35,7 @@ import qonnx.core.onnx_exec as oxe
 from qonnx.core.datatype import DataType
 from qonnx.core.modelwrapper import ModelWrapper
 from qonnx.transformation.infer_shapes import InferShapes
-from qonnx.util.basic import gen_finn_dt_tensor
+from qonnx.util.basic import gen_finn_dt_tensor, qonnx_make_model
 
 
 def test_mnist_onnx_download_extract_run():
@@ -73,7 +73,7 @@ def test_onnx_exec_internal_rounding():
     mul_node = onnx.helper.make_node("Mul", inputs=["inp0", "inp1"], outputs=["outp"])
     graph = onnx.helper.make_graph(nodes=[mul_node], name="mul_graph", inputs=[inp0, inp1], outputs=[outp])
 
-    model = onnx.helper.make_model(graph, producer_name="mul-model")
+    model = qonnx_make_model(graph, producer_name="mul-model")
     model = ModelWrapper(model)
     idt = DataType["INT2"]
     model.set_tensor_datatype("inp0", idt)

--- a/tests/core/test_mixed_onnx_exec.py
+++ b/tests/core/test_mixed_onnx_exec.py
@@ -32,6 +32,7 @@ from onnx import TensorProto, helper
 import qonnx.core.onnx_exec as oxe
 from qonnx.core.modelwrapper import ModelWrapper
 from qonnx.transformation.infer_shapes import InferShapes
+from qonnx.util.basic import qonnx_make_model
 
 
 def test_execute_mixed_model():
@@ -56,7 +57,7 @@ def test_execute_mixed_model():
         outputs=[helper.make_tensor_value_info("out1", TensorProto.FLOAT, [6, 3, 2, 2])],
         value_info=[out0],
     )
-    model_def = helper.make_model(graph_def, producer_name="onnx-example")
+    model_def = qonnx_make_model(graph_def, producer_name="onnx-example")
 
     model = ModelWrapper(model_def)
     model = model.transform(InferShapes())

--- a/tests/core/test_modelwrapper.py
+++ b/tests/core/test_modelwrapper.py
@@ -33,6 +33,7 @@ from pkgutil import get_data
 import qonnx.core.data_layout as DataLayout
 from qonnx.core.datatype import DataType
 from qonnx.core.modelwrapper import ModelWrapper
+from qonnx.util.basic import qonnx_make_model
 
 
 def test_modelwrapper():
@@ -97,7 +98,7 @@ def test_modelwrapper_graph_order():
         ],
     )
 
-    onnx_model = onnx.helper.make_model(graph, producer_name="simple-model")
+    onnx_model = qonnx_make_model(graph, producer_name="simple-model")
     model = ModelWrapper(onnx_model)
 
     # test graph order functions
@@ -146,7 +147,7 @@ def test_modelwrapper_detect_forks_n_joins():
         ],
     )
 
-    onnx_model = onnx.helper.make_model(graph, producer_name="simple-model")
+    onnx_model = qonnx_make_model(graph, producer_name="simple-model")
     model = ModelWrapper(onnx_model)
 
     # test

--- a/tests/custom_op/test_im2col.py
+++ b/tests/custom_op/test_im2col.py
@@ -7,6 +7,7 @@ from qonnx.core.modelwrapper import ModelWrapper
 from qonnx.custom_op.general.im2col import compute_conv_output_dim
 from qonnx.transformation.infer_datatypes import InferDataTypes
 from qonnx.transformation.infer_shapes import InferShapes
+from qonnx.util.basic import qonnx_make_model
 
 
 def execution_im2col(
@@ -48,7 +49,7 @@ def execution_im2col(
 
     graph = helper.make_graph(nodes=[im2col_node], name="im2col_graph", inputs=[inp], outputs=[outp])
 
-    model = helper.make_model(graph, producer_name="im2col-model")
+    model = qonnx_make_model(graph, producer_name="im2col-model")
     model = ModelWrapper(model)
 
     model.set_tensor_datatype("inp", idt)
@@ -1583,7 +1584,7 @@ def test_im2col_infer_shapes():
         outputs=[outp],
     )
 
-    model = helper.make_model(graph, producer_name="shape-model")
+    model = qonnx_make_model(graph, producer_name="shape-model")
     model = ModelWrapper(model)
 
     model.set_tensor_datatype("inp", idt)

--- a/tests/custom_op/test_xnorpopcountmatmul.py
+++ b/tests/custom_op/test_xnorpopcountmatmul.py
@@ -35,6 +35,7 @@ from qonnx.core.datatype import DataType
 from qonnx.core.modelwrapper import ModelWrapper
 from qonnx.transformation.infer_datatypes import InferDataTypes
 from qonnx.transformation.infer_shapes import InferShapes
+from qonnx.util.basic import qonnx_make_model
 
 export_onnx_path = "test_xnorpopcountmatmul.onnx"
 
@@ -47,7 +48,7 @@ def test_xnorpopcountmatmul():
     W = helper.make_tensor_value_info("W", TensorProto.FLOAT, [K, N])
     out = helper.make_tensor_value_info("out", TensorProto.FLOAT, ["x", "y"])
     node_def = helper.make_node("XnorPopcountMatMul", ["x", "W"], ["out"], domain="qonnx.custom_op.general")
-    modelproto = helper.make_model(helper.make_graph([node_def], "test_model", [x], [out], value_info=[W]))
+    modelproto = qonnx_make_model(helper.make_graph([node_def], "test_model", [x], [out], value_info=[W]))
     model = ModelWrapper(modelproto)
     model.set_tensor_datatype("x", DataType["BINARY"])
     model.set_tensor_datatype("W", DataType["BINARY"])

--- a/tests/transformation/test_4d_conversion.py
+++ b/tests/transformation/test_4d_conversion.py
@@ -9,7 +9,7 @@ from qonnx.core.datatype import DataType
 from qonnx.core.modelwrapper import ModelWrapper
 from qonnx.transformation.change_3d_tensors_to_4d import Change3DTo4DTensors
 from qonnx.transformation.infer_shapes import InferShapes
-from qonnx.util.basic import gen_finn_dt_tensor
+from qonnx.util.basic import gen_finn_dt_tensor, qonnx_make_model
 
 
 def generate_random_input(model):
@@ -151,7 +151,7 @@ def create_arbitrary_model(invalid=False):
         outputs=[out1_argmax1],
         value_info=list_of_value_infos,
     )
-    onnx_model = onnx.helper.make_model(graph, producer_name="4d_conversion_test-model")
+    onnx_model = qonnx_make_model(graph, producer_name="4d_conversion_test-model")
     model = ModelWrapper(onnx_model)
     set_all_initializers(model)
 
@@ -258,7 +258,9 @@ def create_arbitrary_model_vgg():
         outputs=[out2_topk1],
         value_info=list_of_value_infos,
     )
-    onnx_model = onnx.helper.make_model(graph, producer_name="4d_conversion_test-model")
+
+    opset_imports = [onnx.helper.make_opsetid("", 11)]
+    onnx_model = qonnx_make_model(graph, producer_name="4d_conversion_test-model", opset_imports=opset_imports)
     model = ModelWrapper(onnx_model)
 
     # Fixed TopK initializer (K=3)

--- a/tests/transformation/test_batchnorm_to_affine.py
+++ b/tests/transformation/test_batchnorm_to_affine.py
@@ -39,7 +39,7 @@ from qonnx.core.modelwrapper import ModelWrapper
 from qonnx.transformation.batchnorm_to_affine import BatchNormToAffine
 from qonnx.transformation.fold_constants import FoldConstants
 from qonnx.transformation.infer_shapes import InferShapes
-from qonnx.util.basic import gen_finn_dt_tensor
+from qonnx.util.basic import gen_finn_dt_tensor, qonnx_make_model
 
 download_url = "https://github.com/onnx/models/raw/main/vision/classification"
 download_url += "/shufflenet/model/shufflenet-9.onnx"
@@ -95,7 +95,7 @@ def test_batchnorm_to_affine_epsilon(epsilon):
         value_info=[s, bias, mean, var],
     )
 
-    onnx_model = onnx.helper.make_model(graph, producer_name="test_batchnorm-model")
+    onnx_model = qonnx_make_model(graph, producer_name="test_batchnorm-model")
     model = ModelWrapper(onnx_model)
 
     model.set_initializer("s", np.array([1, 2, 3]).astype(np.float32))

--- a/tests/transformation/test_change_datalayout.py
+++ b/tests/transformation/test_change_datalayout.py
@@ -39,7 +39,7 @@ from qonnx.transformation.general import GiveReadableTensorNames, GiveUniqueNode
 from qonnx.transformation.infer_data_layouts import InferDataLayouts
 from qonnx.transformation.infer_datatypes import InferDataTypes
 from qonnx.transformation.infer_shapes import InferShapes
-from qonnx.util.basic import gen_finn_dt_tensor, get_by_name
+from qonnx.util.basic import gen_finn_dt_tensor, get_by_name, qonnx_make_model
 
 
 # stride
@@ -85,7 +85,7 @@ def test_change_datalayout_quantavgpool(s, k, ibits, obits, signed, c, idim):
     )
     graph = helper.make_graph(nodes=[node], name="single-quantavgpool", inputs=[inp], outputs=[outp])
 
-    model = helper.make_model(graph)
+    model = qonnx_make_model(graph)
     model = ModelWrapper(model)
     model = model.transform(InferShapes())
     model = model.transform(InferDataTypes())

--- a/tests/transformation/test_conv_lowering.py
+++ b/tests/transformation/test_conv_lowering.py
@@ -42,7 +42,7 @@ from qonnx.custom_op.general.im2col import compute_conv_output_dim
 from qonnx.custom_op.registry import getCustomOp
 from qonnx.transformation.infer_shapes import InferShapes
 from qonnx.transformation.lower_convs_to_matmul import LowerConvsToMatMul
-from qonnx.util.basic import gen_finn_dt_tensor
+from qonnx.util.basic import gen_finn_dt_tensor, qonnx_make_model
 
 
 def test_conv_lowering_convmnist():
@@ -155,7 +155,7 @@ def test_dws_reg_conv_lowering(idt, k_h, k_w, ifm_dim_h, ifm_dim_w, ifm_ch, stri
         value_info=[W] if not bias else [W, B],
     )
 
-    model = oh.make_model(graph, producer_name="test_dws_reg_cnv-model")
+    model = qonnx_make_model(graph, producer_name="test_dws_reg_cnv-model")
     model = ModelWrapper(model)
     model.set_tensor_datatype("inp", idt)
     model.set_tensor_datatype("outp", odt)
@@ -269,7 +269,7 @@ def test_non_equal_padding(idt, k_h, k_w, ifm_dim_h, ifm_dim_w, ifm_ch, stride, 
         value_info=[W],
     )
 
-    model = oh.make_model(graph, producer_name="dws_cnv-model")
+    model = qonnx_make_model(graph, producer_name="dws_cnv-model")
     model = ModelWrapper(model)
     model.set_tensor_datatype("inp", idt)
     model.set_tensor_datatype("outp", odt)
@@ -317,7 +317,7 @@ def test_conv_lowering_conv_1x1():
 
     value_info = [oh.make_tensor_value_info("p1", TensorProto.FLOAT, conv_param_shape)]
 
-    modelproto = oh.make_model(
+    modelproto = qonnx_make_model(
         oh.make_graph(
             name="test",
             inputs=[top_in],

--- a/tests/transformation/test_extend_partition.py
+++ b/tests/transformation/test_extend_partition.py
@@ -37,7 +37,7 @@ from qonnx.core.datatype import DataType
 from qonnx.core.modelwrapper import ModelWrapper
 from qonnx.transformation.create_generic_partitions import PartitionFromDict
 from qonnx.transformation.extend_partition import ExtendPartition
-from qonnx.util.basic import gen_finn_dt_tensor
+from qonnx.util.basic import gen_finn_dt_tensor, qonnx_make_model
 
 
 def create_model():
@@ -231,7 +231,7 @@ def create_model():
         ],
     )
 
-    onnx_model = oh.make_model(graph, producer_name="test_model")
+    onnx_model = qonnx_make_model(graph, producer_name="test_model")
     model = ModelWrapper(onnx_model)
 
     mt_weights = np.random.randint(low=-1000, high=1000, size=[6, 256, 15])

--- a/tests/transformation/test_general_transformation.py
+++ b/tests/transformation/test_general_transformation.py
@@ -40,7 +40,7 @@ from qonnx.custom_op.registry import getCustomOp
 from qonnx.transformation.general import ApplyConfig, ConvertDivToMul, GiveUniqueNodeNames, GiveUniqueParameterTensors
 from qonnx.transformation.infer_shapes import InferShapes
 from qonnx.transformation.lower_convs_to_matmul import LowerConvsToMatMul
-from qonnx.util.basic import gen_finn_dt_tensor
+from qonnx.util.basic import gen_finn_dt_tensor, qonnx_make_model
 
 
 def test_mul_to_div():
@@ -106,7 +106,7 @@ def test_give_unique_parameter_tensors():
         outputs=[out1],
     )
 
-    onnx_model = onnx.helper.make_model(onnx_graph, producer_name="simple-model")
+    onnx_model = qonnx_make_model(onnx_graph, producer_name="simple-model")
     model = ModelWrapper(onnx_model)
 
     # Set param values

--- a/tests/transformation/test_generic_partitioning.py
+++ b/tests/transformation/test_generic_partitioning.py
@@ -37,6 +37,7 @@ from qonnx.custom_op.registry import getCustomOp
 from qonnx.transformation.create_generic_partitions import PartitionFromDict
 from qonnx.transformation.general import GiveReadableTensorNames, GiveUniqueNodeNames
 from qonnx.transformation.infer_shapes import InferShapes
+from qonnx.util.basic import qonnx_make_model
 
 
 # select example partitioning
@@ -71,7 +72,7 @@ def test_generic_partitioning(p):
         value_info=[a0, a1, a2],
     )
 
-    model = helper.make_model(graph, producer_name="model")
+    model = qonnx_make_model(graph, producer_name="model")
     model = ModelWrapper(model)
     # initialize model
     a0_value = np.random.uniform(low=0, high=1, size=(1)).astype(np.float32)

--- a/tests/transformation/test_merge_onnx_models.py
+++ b/tests/transformation/test_merge_onnx_models.py
@@ -40,6 +40,7 @@ from qonnx.transformation.infer_data_layouts import InferDataLayouts
 from qonnx.transformation.infer_datatypes import InferDataTypes
 from qonnx.transformation.infer_shapes import InferShapes
 from qonnx.transformation.merge_onnx_models import MergeONNXModels
+from qonnx.util.basic import qonnx_make_model
 
 
 def test_merge_onnx_models():
@@ -72,7 +73,7 @@ def test_merge_onnx_models():
         value_info=[a0, a1],
     )
 
-    model2 = helper.make_model(graph, producer_name="model2")
+    model2 = qonnx_make_model(graph, producer_name="model2")
     model2 = ModelWrapper(model2)
     # initialize model2
     a0_value = np.random.uniform(low=0, high=1, size=(1)).astype(np.float32)

--- a/tests/transformation/test_remove_identity_ops.py
+++ b/tests/transformation/test_remove_identity_ops.py
@@ -9,7 +9,7 @@ from qonnx.core.modelwrapper import ModelWrapper
 from qonnx.transformation.infer_datatypes import InferDataTypes
 from qonnx.transformation.infer_shapes import InferShapes
 from qonnx.transformation.remove import RemoveIdentityOps
-from qonnx.util.basic import gen_finn_dt_tensor
+from qonnx.util.basic import gen_finn_dt_tensor, qonnx_make_model
 
 
 def insert_identity_op(model, op, as_first_node, approx):
@@ -67,7 +67,7 @@ def test_remove_identity_ops(op, as_first_node, approx):
         value_info=[mul, shape, div, matmul],
     )
 
-    model = helper.make_model(graph, producer_name="mulpastconv-model")
+    model = qonnx_make_model(graph, producer_name="mulpastconv-model")
     model = ModelWrapper(model)
     inp_values = gen_finn_dt_tensor(DataType["INT2"], [1, 4, 1, 1])
     mul_values = np.random.uniform(low=0.1, high=0.99, size=(1)).astype(np.float32)

--- a/tests/transformation/test_sort_graph.py
+++ b/tests/transformation/test_sort_graph.py
@@ -7,6 +7,7 @@ import qonnx.analysis.topology as ta
 from qonnx.core.modelwrapper import ModelWrapper
 from qonnx.transformation.general import SortGraph
 from qonnx.transformation.infer_shapes import InferShapes
+from qonnx.util.basic import qonnx_make_model
 
 
 def make_randomly_sorted_linear_model(num_of_nodes, seed=None):
@@ -28,7 +29,7 @@ def make_randomly_sorted_linear_model(num_of_nodes, seed=None):
 
     nodes = np.random.permutation(nodes)
 
-    modelproto = helper.make_model(
+    modelproto = qonnx_make_model(
         helper.make_graph(
             name="test",
             inputs=[top_in],
@@ -69,7 +70,7 @@ def test_sort_nonlinear_graph():
     for i in range(num_of_params):
         value_info += [helper.make_tensor_value_info("p" + str(i), TensorProto.FLOAT, input_shape)]
 
-    modelproto = helper.make_model(
+    modelproto = qonnx_make_model(
         helper.make_graph(
             name="test",
             inputs=[top_in],


### PR DESCRIPTION
Change the pinned dependency package versions as follows:
`protobuf==3.20.1` --> `protobuf==3.20.3`
`onnx==1.11.0` -->    `onnx==1.13.0`

Note that the version changes in onnx break how test models are created in the qonnx test code, so a new utility function `qonnx_make_model` that explicitly sets the opset version is introduced for creation of test models. Opset 9 is preferred but can be overridden at model creation time. Relevant qonnx tests have been updated to use this function instead of the `onnx.helper.make_model`