### PR TITLE
Changed default ONNX opset version

### DIFF
--- a/src/qonnx/util/basic.py
+++ b/src/qonnx/util/basic.py
@@ -38,7 +38,7 @@ from qonnx.core.datatype import DataType
 
 def get_preferred_onnx_opset():
     "Return preferred ONNX opset version for QONNX"
-    return 9
+    return 11
 
 
 def qonnx_make_model(graph_proto, **kwargs):


### PR DESCRIPTION
We observed an error in some tests in the FINN compiler when using the function `qonnx_make_model`. Specifically, an ONNXRuntimeError was thrown for the `TopK` node. It seems like, by specifying opset version 9 when creating the ModelProto, the TopK node would fall back to opset version 1. In this version, the node only has a single input, while the FINN compiler instantiates the node on the assumption of another opset version (either 10 or 11 -- i.e. two inputs).
A solution is to default to ONNX opset version 11.