### PR TITLE
Add ability to pass onnx opset information to custom ops 

### DIFF
--- a/src/qonnx/core/execute_custom_node.py
+++ b/src/qonnx/core/execute_custom_node.py
@@ -27,15 +27,16 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import qonnx.custom_op.registry as registry
+from qonnx.util.basic import get_preferred_onnx_opset
 
 
-def execute_custom_node(node, context, graph):
+def execute_custom_node(node, context, graph, onnx_opset_version=get_preferred_onnx_opset()):
     """Call custom implementation to execute a single custom node.
     Input/output provided via context."""
     op_type = node.op_type
     try:
         # lookup op_type in registry of CustomOps
-        inst = registry.getCustomOp(node)
+        inst = registry.getCustomOp(node, onnx_opset_version=onnx_opset_version)
         inst.execute_node(context, graph)
     except KeyError:
         # exception if op_type is not supported

--- a/src/qonnx/core/onnx_exec.py
+++ b/src/qonnx/core/onnx_exec.py
@@ -34,16 +34,22 @@ import onnxruntime as rt
 
 import qonnx.analysis.topology as ta
 import qonnx.core.execute_custom_node as ex_cu_node
-from qonnx.util.basic import get_sanitize_quant_tensors, is_finn_op, qonnx_make_model, sanitize_quant_values
+from qonnx.util.basic import (
+    get_preferred_onnx_opset,
+    get_sanitize_quant_tensors,
+    is_finn_op,
+    qonnx_make_model,
+    sanitize_quant_values,
+)
 
 
-def execute_node(node, context, graph, return_full_exec_context=False, opset_version=9):
+def execute_node(node, context, graph, return_full_exec_context=False, opset_version=get_preferred_onnx_opset()):
     """Executes a single node by using onnxruntime or with a custom function.
 
     Input/output provided via context."""
 
     if is_finn_op(node.domain):
-        ex_cu_node.execute_custom_node(node, context, graph)
+        ex_cu_node.execute_custom_node(node, context, graph, onnx_opset_version=opset_version)
     else:
         # onnxruntime unfortunately does not implement run_node as defined by ONNX,
         # it can only execute entire models -- so we create a model which solely

--- a/src/qonnx/custom_op/base.py
+++ b/src/qonnx/custom_op/base.py
@@ -30,7 +30,7 @@ import onnx.helper as helper
 import onnx.numpy_helper as np_helper
 from abc import ABC, abstractmethod
 
-from qonnx.util.basic import get_by_name
+from qonnx.util.basic import get_by_name, get_preferred_onnx_opset
 
 
 class CustomOp(ABC):
@@ -38,9 +38,10 @@ class CustomOp(ABC):
     every custom node should have. Some as abstract methods, these have to be
     filled when writing a new custom op node."""
 
-    def __init__(self, onnx_node):
+    def __init__(self, onnx_node, onnx_opset_version=get_preferred_onnx_opset()):
         super().__init__()
         self.onnx_node = onnx_node
+        self.onnx_opset_version = onnx_opset_version
 
     def get_nodeattr_def(self, name):
         """Return 4-tuple (dtype, required, default_val, allowed_values) for attribute

--- a/src/qonnx/custom_op/channels_last/base_wrapped_op.py
+++ b/src/qonnx/custom_op/channels_last/base_wrapped_op.py
@@ -2,6 +2,7 @@ import numpy as np
 import onnxruntime as rt
 from copy import deepcopy
 from onnx import TensorProto, helper
+from onnx.helper import make_opsetid
 
 from qonnx.custom_op.base import CustomOp
 from qonnx.util.basic import qonnx_make_model
@@ -59,6 +60,11 @@ class ChannelsLastWrappedOp(CustomOp):
     def execute_node(self, context, graph):
         node = self.onnx_node
 
+        # Get opset
+        opset_version = self.onnx_opset_version
+        opset_imports = [make_opsetid("", opset_version)]
+        onnx_kwargs = {"opset_imports": opset_imports}
+
         # Create an intermediate node and remove the domain
         # This enables us to use onnxrutime to execute this node.
         intermediate_node = deepcopy(node)
@@ -97,7 +103,7 @@ class ChannelsLastWrappedOp(CustomOp):
         # Execute the intermediate node with onnxruntime,
         # using the transposed inputs / outputs
         intermediate_graph = helper.make_graph([intermediate_node], "test_model", input_tensor_list, output_tensor_list)
-        intermediate_model = qonnx_make_model(intermediate_graph)
+        intermediate_model = qonnx_make_model(intermediate_graph, **onnx_kwargs)
         sess = rt.InferenceSession(intermediate_model.SerializeToString())
         output_list = sess.run(None, input_dict)
         output_onnx = output_list[0]

--- a/src/qonnx/custom_op/channels_last/conv.py
+++ b/src/qonnx/custom_op/channels_last/conv.py
@@ -140,10 +140,10 @@ class Conv(ChannelsLastWrappedOp):
             verification_successful = False
 
         # verify the number of inputs
-        if len(node.input) == 2:
+        if len(node.input) == 2 or len(node.input) == 3:
             info_messages.append("The number of inputs is correct")
         else:
-            info_messages.append("{} needs 2 data inputs".format(node.op_type))
+            info_messages.append("{} needs 2 or 3 data inputs".format(node.op_type))
             verification_successful = False
 
         if not verification_successful:

--- a/src/qonnx/custom_op/channels_last/max_pool.py
+++ b/src/qonnx/custom_op/channels_last/max_pool.py
@@ -94,14 +94,15 @@ class MaxPool(ChannelsLastWrappedOp):
         info_messages.extend(wrapper_info)
 
         # verify number of attributes
-        num_of_attr = 3
-        if len(node.attribute) == num_of_attr:
+        num_of_attr_min = 3
+        num_of_attr_max = 7
+        if (len(node.attribute) >= num_of_attr_min) and len(node.attribute) <= num_of_attr_max:
             info_messages.append("The number of attributes is correct")
         else:
             info_messages.append(
                 """The number of attributes is incorrect,
-            {} should have {} attributes""".format(
-                    node.op_type, num_of_attr
+            {} should have between {} and {} attributes""".format(
+                    node.op_type, num_of_attr_min, num_of_attr_max
                 )
             )
             verification_successful = False

--- a/src/qonnx/custom_op/registry.py
+++ b/src/qonnx/custom_op/registry.py
@@ -28,8 +28,10 @@
 
 import importlib
 
+from qonnx.util.basic import get_preferred_onnx_opset
 
-def getCustomOp(node):
+
+def getCustomOp(node, onnx_opset_version=get_preferred_onnx_opset()):
     "Return a QONNX CustomOp instance for the given ONNX node, if it exists."
     op_type = node.op_type
     domain = node.domain
@@ -37,7 +39,7 @@ def getCustomOp(node):
         opset_module = importlib.import_module(domain)
         assert type(opset_module.custom_op) is dict, "custom_op dict not found in Python module %s" % domain
         inst_wrapper = opset_module.custom_op[op_type]
-        inst = inst_wrapper(node)
+        inst = inst_wrapper(node, onnx_opset_version=onnx_opset_version)
         return inst
     except ModuleNotFoundError:
         raise Exception("Could not load custom opset %s, check your PYTHONPATH" % domain)

--- a/src/qonnx/transformation/channels_last.py
+++ b/src/qonnx/transformation/channels_last.py
@@ -109,6 +109,9 @@ class InsertChannelsLastDomainsAndTrafos(Transformation):
                     # these don't need a transpose.
                     if n.op_type == "BatchNormalization" and i > 0:
                         continue
+                    # Skip Conv bias since it doesn't need a transpose
+                    if n.op_type == "Conv" and i == 2:
+                        continue
                     # Get the shape of the input tensor
                     # and convert it to the shape for the intermediate tensor
                     chanFirst_shape = model.get_tensor_shape(inp)

--- a/src/qonnx/util/cleanup.py
+++ b/src/qonnx/util/cleanup.py
@@ -2,7 +2,6 @@ import clize
 
 from qonnx.core.modelwrapper import ModelWrapper
 from qonnx.transformation.fold_constants import FoldConstants
-from qonnx.transformation.gemm_to_matmul import GemmToMatMul
 from qonnx.transformation.general import (
     GiveReadableTensorNames,
     GiveUniqueNodeNames,
@@ -31,7 +30,6 @@ def cleanup_model(model):
     cleanup_transformations = [
         InferShapes(),
         GiveUniqueParameterTensors(),
-        GemmToMatMul(),
         FoldConstants(exclude_op_types=["Quant", "BipolarQuant"]),
         FoldTransposeIntoQuantInit(),
         RemoveUnusedTensors(),

--- a/src/qonnx/util/cleanup.py
+++ b/src/qonnx/util/cleanup.py
@@ -2,6 +2,7 @@ import clize
 
 from qonnx.core.modelwrapper import ModelWrapper
 from qonnx.transformation.fold_constants import FoldConstants
+from qonnx.transformation.gemm_to_matmul import GemmToMatMul
 from qonnx.transformation.general import (
     GiveReadableTensorNames,
     GiveUniqueNodeNames,
@@ -30,6 +31,7 @@ def cleanup_model(model):
     cleanup_transformations = [
         InferShapes(),
         GiveUniqueParameterTensors(),
+        GemmToMatMul(),
         FoldConstants(exclude_op_types=["Quant", "BipolarQuant"]),
         FoldTransposeIntoQuantInit(),
         RemoveUnusedTensors(),

--- a/tests/transformation/test_channelslast.py
+++ b/tests/transformation/test_channelslast.py
@@ -51,6 +51,15 @@ model_details = {
         "input_range": (-1, +1),
         "layout_sensitive": True,
     },
+    "Conv_bias_example": {
+        "url": (
+            "https://raw.githubusercontent.com/julesmuhizi/pytorch_hls4ml/7f4459de1d69c1642dd858ff1a970509a61ff017"
+            "/model/CNN/super_resolution.onnx"
+        ),
+        "input_shape": (1, 1, 28, 28),
+        "input_range": (-1, +1),
+        "layout_sensitive": True,
+    },
 }
 
 
@@ -157,7 +166,9 @@ def test_channelslast_conversion_end2end(test_model, make_input_channels_last):
     input_dict = {model.graph.input[0].name: input_tensor}
     output_dict = oxe.execute_onnx(model, input_dict)
     current_result = output_dict[model.graph.output[0].name]
-    assert (golden_result == current_result).all(), "Output of cleaned QONNX model and channels last model should match."
+    assert np.isclose(
+        golden_result, current_result, atol=1e-7
+    ).all(), "Output of cleaned QONNX model and channels last model should match."
     assert model.check_all_tensor_shapes_specified(), "All tensor shapes should be specified."
 
     # Check that the ops, which should be ChannelsLast actually are
@@ -191,8 +202,8 @@ def test_channelslast_conversion_step_by_step(test_model):
     input_dict = {model.graph.input[0].name: input_tensor}
     output_dict = oxe.execute_onnx(model, input_dict)
     current_result = output_dict[model.graph.output[0].name]
-    assert (
-        golden_result == current_result
+    assert np.isclose(
+        golden_result, current_result, atol=1e-7
     ).all(), "Output of cleaned QONNX model and model after applying InsertChannelsLastDomainsAndTrafos should match."
     assert model.check_all_tensor_shapes_specified(), "All tensor shapes should be specified."
 
@@ -202,8 +213,8 @@ def test_channelslast_conversion_step_by_step(test_model):
     input_dict = {model.graph.input[0].name: input_tensor}
     output_dict = oxe.execute_onnx(model, input_dict)
     current_result = output_dict[model.graph.output[0].name]
-    assert (
-        golden_result == current_result
+    assert np.isclose(
+        golden_result, current_result, atol=1e-7
     ).all(), (
         "Output of cleaned QONNX model and model after applying RemoveConsecutiveChanFirstAndChanLastTrafos should match."
     )
@@ -215,8 +226,8 @@ def test_channelslast_conversion_step_by_step(test_model):
     input_dict = {model.graph.input[0].name: input_tensor}
     output_dict = oxe.execute_onnx(model, input_dict)
     current_result = output_dict[model.graph.output[0].name]
-    assert (
-        golden_result == current_result
+    assert np.isclose(
+        golden_result, current_result, atol=1e-7
     ).all(), "Output of cleaned QONNX model and model after applying MoveChanLastUpstream should match."
     assert model.check_all_tensor_shapes_specified(), "All tensor shapes should be specified."
 
@@ -226,8 +237,8 @@ def test_channelslast_conversion_step_by_step(test_model):
     input_dict = {model.graph.input[0].name: input_tensor}
     output_dict = oxe.execute_onnx(model, input_dict)
     current_result = output_dict[model.graph.output[0].name]
-    assert (
-        golden_result == current_result
+    assert np.isclose(
+        golden_result, current_result, atol=1e-7
     ).all(), "Output of cleaned QONNX model and model after applying MoveChanLastUpstream should match."
     assert model.check_all_tensor_shapes_specified(), "All tensor shapes should be specified."
 
@@ -237,8 +248,8 @@ def test_channelslast_conversion_step_by_step(test_model):
     input_dict = {model.graph.input[0].name: input_tensor}
     output_dict = oxe.execute_onnx(model, input_dict)
     current_result = output_dict[model.graph.output[0].name]
-    assert (
-        golden_result == current_result
+    assert np.isclose(
+        golden_result, current_result, atol=1e-7
     ).all(), (
         "Output of cleaned QONNX model and model after applying RemoveConsecutiveChanFirstAndChanLastTrafos should match."
     )
@@ -250,8 +261,8 @@ def test_channelslast_conversion_step_by_step(test_model):
     input_dict = {model.graph.input[0].name: input_tensor}
     output_dict = oxe.execute_onnx(model, input_dict)
     current_result = output_dict[model.graph.output[0].name]
-    assert (
-        golden_result == current_result
+    assert np.isclose(
+        golden_result, current_result, atol=1e-7
     ).all(), "Output of cleaned QONNX model and model after applying MoveChanFirstDownstream should match."
     assert model.check_all_tensor_shapes_specified(), "All tensor shapes should be specified."
 
@@ -262,8 +273,8 @@ def test_channelslast_conversion_step_by_step(test_model):
     input_dict = {model.graph.input[0].name: input_tensor}
     output_dict = oxe.execute_onnx(model, input_dict)
     current_result = output_dict[model.graph.output[0].name]
-    assert (
-        golden_result == current_result
+    assert np.isclose(
+        golden_result, current_result, atol=1e-7
     ).all(), "Output of cleaned QONNX model and model after applying AbsorbChanFirstIntoMatMul should match."
     assert model.check_all_tensor_shapes_specified(), "All tensor shapes should be specified."
 
@@ -276,8 +287,8 @@ def test_channelslast_conversion_step_by_step(test_model):
     input_dict = {model.graph.input[0].name: input_tensor}
     output_dict = oxe.execute_onnx(model, input_dict)
     current_result = output_dict[model.graph.output[0].name]
-    assert (
-        golden_result == current_result
+    assert np.isclose(
+        golden_result, current_result, atol=1e-7
     ).all(), "Output of cleaned QONNX model and model after applying AbsorbChanFirstIntoMatMul should match."
     assert model.check_all_tensor_shapes_specified(), "All tensor shapes should be specified."
 


### PR DESCRIPTION
Hi,
this PR addresses the issue that channels last ops have currently no way of telling which onnx opset version is supposed to be used for inference.
To this end the base class for custom ops as been extended to carry this information and the execution functions have been extended to pass it along.

