### PR TITLE
Fixes and improvements to constant folding and subgraph execution

### DIFF
--- a/src/qonnx/core/onnx_exec.py
+++ b/src/qonnx/core/onnx_exec.py
@@ -31,6 +31,7 @@ import copy
 import numpy as np
 import onnx.helper as helper
 import onnxruntime as rt
+import warnings
 
 import qonnx.analysis.topology as ta
 import qonnx.core.execute_custom_node as ex_cu_node
@@ -84,10 +85,10 @@ def execute_node(node, context, graph, return_full_exec_context=False, opset_ver
 
             # use that index to index output_list
             if output_list[list_ind].shape != context[outp].shape:
-                raise Exception(
-                    """Output shapes disagree after node execution:
+                warnings.warn(
+                    """Output shapes disagree after node %s execution:
                     found %s vs expected %s"""
-                    % (str(output_list[list_ind].shape), str(context[outp].shape))
+                    % (str(node), str(output_list[list_ind].shape), str(context[outp].shape))
                 )
             context[outp] = output_list[list_ind]
 

--- a/src/qonnx/core/onnx_exec.py
+++ b/src/qonnx/core/onnx_exec.py
@@ -59,6 +59,13 @@ def execute_node(node, context, graph, return_full_exec_context=False, opset_ver
         node_inputs += list(filter(lambda x: x.name in node.input, graph.value_info))
         node_outputs = list(filter(lambda x: x.name in node.output, graph.output))
         node_outputs += list(filter(lambda x: x.name in node.output, graph.value_info))
+        for attr in node.attribute:
+            if attr.type == 5:
+                subgraph = attr.g
+                for subgraph_node in subgraph.node:
+                    subgraph_node_inputs = list(filter(lambda x: x.name in subgraph_node.input, graph.value_info))
+                    new_inps = list(filter(lambda x: x not in node_inputs, subgraph_node_inputs))
+                    node_inputs += new_inps
         node_graph = helper.make_graph(
             nodes=[node],
             name="single-node-exec",

--- a/src/qonnx/transformation/remove.py
+++ b/src/qonnx/transformation/remove.py
@@ -83,8 +83,14 @@ class RemoveIdentityOps(Transformation):
                     break
             elif n.op_type == "Pad" and not model.is_fork_node(n) and not model.is_join_node(n):
                 pads = get_by_name(n.attribute, "pads")
-                pads = np.asarray(pads.ints, dtype=np.int64)
-                if (pads == 0).all():
+                if pads is not None:
+                    # older versions of Pad op specify pads as attribute
+                    pads = np.asarray(pads.ints, dtype=np.int64)
+                else:
+                    # newer versions of Pad op specify pads as input
+                    pads = model.get_initializer(n.input[1])
+
+                if (pads is not None) and (pads == 0).all():
                     remove_node_and_rewire(model, n)
                     graph_modified = True
                     break


### PR DESCRIPTION
- `FoldConstants` now respects the opset while performing constant folding. Small additional fixes on missing ValueInfo fields and separation of removal for const-folded nodes in a separate step at the end of the transformation.
- Basic support for execution of subgraphs. This is not well tested but still improves upon the prior state of the code when it comes to any ONNX models with subgraphs included.
- Handle newer versions of `Pad` nodes for `RemoveIdentityOps`