### PR TITLE
QONNX to QCDQ conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,16 @@ Inference cost for CNV_2W2A.onnx
 
 You can read more about the BOPS metric in [this paper](https://www.frontiersin.org/articles/10.3389/frai.2021.676564/full), Section 4.2 Bit Operations.
 
-### Development
+### Convert between different quantization representations
+
+Using the `qonnx-convert` command line utility you can convert from QONNX to QCDQ-style quantization:
+
+`qonnx-convert CNV_2W2A.onnx`
+
+This will convert `Quant` nodes to `QuantizeLinear -> Clip -> DequantizeLinear` nodes where possible.
+Please see the documentation of the `QuantToQCDQ` transformation to learn more about the limitations.
+
+## Development
 
 Install in editable mode in a venv:
 
@@ -110,7 +119,7 @@ git clone https://github.com/fastmachinelearning/qonnx
 cd qonnx
 virtualenv -p python3.8 venv
 source venv/bin/activate
-pip install -e .[qkeras,testing]
+pip install -e .[qkeras,testing,docs]
 ```
 
 Run entire test suite, parallelized across CPU cores:

--- a/setup.cfg
+++ b/setup.cfg
@@ -90,6 +90,7 @@ console_scripts =
     qonnx-exec = qonnx.util.exec_qonnx:main
     qonnx-to-channels-last = qonnx.util.to_channels_last:main
     qonnx-inference-cost = qonnx.util.inference_cost:main
+    qonnx-convert = qonnx.util.convert:main
 pytest_randomly.random_seeder =
     qonnx = qonnx.util.random_reseed:reseed
 # Add here console scripts like:

--- a/src/qonnx/custom_op/registry.py
+++ b/src/qonnx/custom_op/registry.py
@@ -31,10 +31,13 @@ import importlib
 from qonnx.util.basic import get_preferred_onnx_opset
 
 
-def getCustomOp(node, onnx_opset_version=get_preferred_onnx_opset()):
+def getCustomOp(node, onnx_opset_version=get_preferred_onnx_opset(), brevitas_exception=True):
     "Return a QONNX CustomOp instance for the given ONNX node, if it exists."
     op_type = node.op_type
     domain = node.domain
+    if brevitas_exception:
+        # transparently resolve Brevitas domain ops to qonnx ones
+        domain = domain.replace("onnx.brevitas", "qonnx.custom_op.general")
     try:
         opset_module = importlib.import_module(domain)
         assert type(opset_module.custom_op) is dict, "custom_op dict not found in Python module %s" % domain

--- a/src/qonnx/transformation/qonnx_to_qcdq.py
+++ b/src/qonnx/transformation/qonnx_to_qcdq.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2023 Advanced Micro Devices, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of qonnx nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import numpy as np
+from onnx import TensorProto
+from onnx import helper as oh
+from warnings import warn
+
+from qonnx.core.modelwrapper import ModelWrapper
+from qonnx.custom_op.general.quant import max_int, min_int
+from qonnx.custom_op.registry import getCustomOp
+from qonnx.transformation.base import Transformation
+from qonnx.transformation.general import RemoveUnusedTensors
+
+
+class QuantToQCDQ(Transformation):
+    """Replace QONNX Quant-style quantization nodes with QuantizeLinear
+    -> Clip -> DequantizeLinear (QCDQ)-style quantization nodes. The following
+    restictions apply on the Quant:
+    - the scale, zero-point and bitwidth inputs for Quant must be statically specified
+      by an initializer
+    - the bitwidth must be an integer in the range [2, 8]
+    - the zero-point tensor must be zero
+    - the scale must be a scalar value or 1D tensor
+    - the rounding_mode attribute must be ROUND
+    BipolarQuant is not (yet) supported.
+    """
+
+    def apply(self, model: ModelWrapper):
+        graph = model.graph
+        graph_modified = False
+        nodes_to_remove = []
+        for node in graph.node:
+            if node.op_type == "Quant":
+                # check all conditions for conversion
+                inp_tname = node.input[0]
+                scale_tname = node.input[1]
+                zeropt_tname = node.input[2]
+                bitwidth_tname = node.input[3]
+                out_tname = node.output[0]
+                scale_t = model.get_initializer(scale_tname)
+                zeropt_t = model.get_initializer(zeropt_tname)
+                bitwidth_t = model.get_initializer(bitwidth_tname)
+                qnt_inst = getCustomOp(node)
+                narrow = bool(qnt_inst.get_nodeattr("narrow"))
+                signed = bool(qnt_inst.get_nodeattr("signed"))
+                rounding_mode = qnt_inst.get_nodeattr("rounding_mode")
+                last_node = node
+                if zeropt_t is None or zeropt_t != 0:
+                    warn("Zeropoint is undefined or nonzero, skipping " + node.name)
+                    continue
+                if scale_t is None or (scale_t.ndim not in [0, 1]):
+                    warn("Scale is undefined or non-0/1D, skipping " + node.name)
+                    continue
+                if bitwidth_tname is None or bitwidth_t.ndim != 0:
+                    warn("Bitwidth is undefined or non-scalar, skipping " + node.name)
+                    continue
+                if bitwidth_t < 2 or bitwidth_t > 8:
+                    warn("Bitwidth outside supported range [2,8], skipping " + node.name)
+                    continue
+                if rounding_mode != "ROUND":
+                    warn("Rounding mode is not ROUND, skipping " + node.name)
+                    continue
+                graph_modified = True
+                # create new zeropoint tensor with appropriate dtype
+                new_dtype = TensorProto.INT8 if signed else TensorProto.UINT8
+                new_dtype_np = np.int8 if signed else np.uint8
+                new_zeropt_name = model.make_new_valueinfo_name()
+                new_zeropt_vi = oh.make_tensor_value_info(new_zeropt_name, new_dtype, scale_t.shape)
+                new_zeropt_t = np.asarray(0, dtype=new_dtype_np)
+                graph.value_info.append(new_zeropt_vi)
+                model.set_initializer(new_zeropt_name, new_zeropt_t)
+                new_qout_name = model.make_new_valueinfo_name()
+                ishape = model.get_tensor_shape(inp_tname)
+                new_qout_vi = oh.make_tensor_value_info(new_qout_name, new_dtype, ishape)
+                graph.value_info.append(new_qout_vi)
+                # create the QuantizeLinear node
+                new_node_qnt = oh.make_node("QuantizeLinear", [inp_tname, scale_tname, new_zeropt_name], [new_qout_name])
+                graph.node.insert(model.get_node_index(last_node) + 1, new_node_qnt)
+                last_out_tname = new_qout_name
+                last_node = new_node_qnt
+                # determine whether clipping is needed
+                # insert a Clip node if so
+                bitwidth = int(bitwidth_t)
+                range_min = min_int(signed, narrow, bitwidth)
+                range_max = max_int(signed, narrow, bitwidth)
+                if signed and narrow:
+                    new_clip_oname = model.make_new_valueinfo_name()
+                    new_clip_vi = oh.make_tensor_value_info(new_clip_oname, new_dtype, ishape)
+                    graph.value_info.append(new_clip_vi)
+                    new_clip_min = model.make_new_valueinfo_name()
+                    new_clip_min_t = np.asarray(range_min, dtype=new_dtype_np)
+                    # set_initializer will create the missing VIs for the
+                    # clip min/max tensors here
+                    model.set_initializer(new_clip_min, new_clip_min_t)
+                    new_clip_max = model.make_new_valueinfo_name()
+                    new_clip_max_t = np.asarray(range_max, dtype=new_dtype_np)
+                    model.set_initializer(new_clip_max, new_clip_max_t)
+                    new_node_clip = oh.make_node("Clip", [last_out_tname, new_clip_min, new_clip_max], [new_clip_oname])
+                    last_out_tname = new_clip_oname
+                    graph.node.insert(model.get_node_index(last_node) + 1, new_node_clip)
+                    last_node = new_node_clip
+                # finally add the DequantizeLinear node
+                new_node_deqnt = oh.make_node(
+                    "DequantizeLinear", [last_out_tname, scale_tname, new_zeropt_name], [out_tname]
+                )
+                graph.node.insert(model.get_node_index(last_node) + 1, new_node_deqnt)
+                last_node = new_node_deqnt
+                nodes_to_remove.append(node)
+        for node_to_remove in nodes_to_remove:
+            graph.node.remove(node_to_remove)
+        if graph_modified:
+            # remove old tensors that are no longer used for bitwidth, zeropt etc
+            model = model.transform(RemoveUnusedTensors())
+            # ensure opset version is new enough for the Clip nodes we inserted
+            clip_min_opset = 13
+            if model.model.opset_import[0].version < clip_min_opset:
+                warn(
+                    "QCDQ Clip requires ONNX opset >= %d but found %d"
+                    % (clip_min_opset, model.model.opset_import[0].version)
+                )
+                warn("Forcing opset version %s upgrade to ensure valid ONNX" % clip_min_opset)
+                model.model.opset_import[0].version = clip_min_opset
+
+        return (model, graph_modified)

--- a/src/qonnx/util/convert.py
+++ b/src/qonnx/util/convert.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2023 Advanced Micro Devices, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of qonnx nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import clize
+
+from qonnx.core.modelwrapper import ModelWrapper
+from qonnx.transformation.qonnx_to_qcdq import QuantToQCDQ
+
+
+def convert(input_model_file, output_style: str = "qcdq", output_file: str = None):
+    """Convert an ONNX file from one style of quantization to another, where possible.
+    Currently, the input model must be QONNX (Quant nodes) and only QCDQ is supported
+    as the conversion target. Please see the documentation on the QuantToQCDQ
+    transformation to learn more about the particular limitations.
+
+    :param input_model_file: Filename for the input ONNX model.
+    :param output_style: Quantization style for the output. Currently only 'qcdq'
+    :param output_file: If specified, write the output ONNX model to this filename.
+        Otherwise, will default to the input file with an _output_style suffix.
+    """
+    model = ModelWrapper(input_model_file)
+    if output_style == "qcdq":
+        model = model.transform(QuantToQCDQ())
+    else:
+        print("Unknown output_style for conversion: %s" % output_style)
+        exit(-1)
+    if output_file is None:
+        output_file = input_model_file.replace(".onnx", "_%s.onnx" % output_style)
+    model.save(output_file)
+
+
+def main():
+    clize.run(convert)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/transformation/test_qonnx_to_qcdq.py
+++ b/tests/transformation/test_qonnx_to_qcdq.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2023 Advanced Micro Devices, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of qonnx nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import numpy as np
+import os
+import urllib.request
+
+import qonnx.core.onnx_exec as oxe
+from qonnx.core.modelwrapper import ModelWrapper
+from qonnx.transformation.qonnx_to_qcdq import QuantToQCDQ
+from qonnx.util.cleanup import cleanup_model
+
+model_details = {
+    "FINN-CNV_W2A2": {
+        "url": (
+            "https://raw.githubusercontent.com/fastmachinelearning/"
+            "QONNX_model_zoo/main/models/CIFAR10/Brevitas_FINN_CNV/CNV_2W2A.onnx"
+        ),
+        "input_shape": (1, 3, 32, 32),
+        "input_range": (-1, +1),
+        "layout_sensitive": True,
+    },
+    "FINN-TFC_W2A2": {
+        "url": (
+            "https://github.com/fastmachinelearning/QONNX_model_zoo/"
+            "raw/main/models/MNIST/Brevitas_FINN_TFC/TFC/TFC_2W2A.onnx"
+        ),
+        "input_shape": (1, 1, 28, 28),
+        "input_range": (-1, +1),
+        "layout_sensitive": False,
+    },
+    "RadioML_VGG10": {
+        "url": (
+            "https://github.com/Xilinx/brevitas-radioml-challenge-21/raw/"
+            "9eef6a2417d6a0c078bfcc3a4dc95033739c5550/sandbox/notebooks/models/pretrained_VGG10_w8a8_20_export.onnx"
+        ),
+        "input_shape": (1, 2, 1024),
+        "input_range": (-1, +1),
+        "layout_sensitive": True,
+    },
+}
+
+
+def download_model(test_model):
+    qonnx_url = model_details[test_model]["url"]
+    # download test data
+    dl_dir = "/tmp"
+    dl_file = dl_dir + f"/{test_model}.onnx"
+    urllib.request.urlretrieve(qonnx_url, dl_file)
+    return dl_file
+
+
+def get_golden_in_and_output(model, test_model):
+    rng = np.random.RandomState(42)
+    input_shape = model_details[test_model]["input_shape"]
+    (low, high) = model_details[test_model]["input_range"]
+    size = np.prod(np.asarray(input_shape))
+    input_tensor = rng.uniform(low=low, high=high, size=size)
+    input_tensor = input_tensor.astype(np.float32)
+    input_tensor = input_tensor.reshape(input_shape)
+    input_dict = {model.graph.input[0].name: input_tensor}
+    golden_output_dict = oxe.execute_onnx(model, input_dict)
+    golden_result = golden_output_dict[model.graph.output[0].name]
+    return input_tensor, golden_result
+
+
+def test_qonnx_to_qcdq():
+    test_model = "FINN-TFC_W2A2"
+    dl_file = download_model(test_model=test_model)
+    assert os.path.isfile(dl_file)
+    model = ModelWrapper(dl_file)
+    model = cleanup_model(model)
+    input_tensor, golden_result = get_golden_in_and_output(model, test_model)
+    model = model.transform(QuantToQCDQ())
+    model = cleanup_model(model)
+    input_dict = {model.graph.input[0].name: input_tensor}
+    produced_output_dict = oxe.execute_onnx(model, input_dict)
+    produced_result = produced_output_dict[model.graph.output[0].name]
+    assert np.isclose(golden_result, produced_result).all()
+    os.unlink(dl_file)


### PR DESCRIPTION
This PR introduces a transformation `QuantToQCDQ` as well as an accompanying command line utility `qonnx-convert` to convert from the QONNX (`Quant`) style of representation to the QCDQ (`QuantizeLinear -> Clip -> DequantizeLinear`) style. For networks where this is possible, the QCDQ style only uses ONNX-standard nodes, which may be preferrable for some reasons (e.g. inference speed in pure `onnxruntime` or compatibility with other downstream frameworks). The behavior is tested by checking equivalence pre/post-conversion for several QONNX Model Zoo examples in `test_qonnx_to_qcdq.py`.

The following restictions apply on the `Quant` nodes for conversion:
    - the scale, zero-point and bitwidth inputs for `Quant` must be statically specified by an initializer
    - the bitwidth must be an integer in the range [2, 8]
    - the zero-point tensor must be zero
    - the scale must be a scalar value or 1D tensor
    - the rounding_mode attribute must be ROUND

BipolarQuant is not (yet) supported since it does not cleanly map to `QuantizeLinear` nodes and is left as future work.