### PR TITLE
Introduce scaled integer datatypes for inference cost

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ odict = execute_onnx(idict)
 
 ### Calculate inference cost for QONNX model
 
-Using the `qonnx-inference-cost` command line utility:
+Using the `qonnx-inference-cost` command line utility for the [CNV_2W2A example](https://github.com/fastmachinelearning/qonnx_model_zoo/tree/main/models/CIFAR10/Brevitas_FINN_CNV):
 
 `qonnx-inference-cost CNV_2W2A.onnx`
 
@@ -83,18 +83,18 @@ Which will print a inference cost dictionary like the following:
 ```
 Inference cost for CNV_2W2A.onnx
 {
-  "discount_sparsity": true,    # discount MAC counts by layer sparsity (disregard zero-valued MACs)
+  "discount_sparsity": true,    # discount MAC counts by layer sparsity (disregard zero-valued MACs and params)
   # mem_o_X: number of layer outputs with datatype X
-  "mem_o_FLOAT32": 57600.0,     # number of FLOAT32 output elements
-  "mem_o_INT32": 85002.0,       # number of INT32 output elements
+  "mem_o_INT32": 142602.0,       # number of INT32 output elements
   # mem_o_X: number of layer parameters (weights) with datatype X
-  "mem_w_INT2": 1144512.0,      # number of INT2 parameters (weights)
+  "mem_w_INT2": 908033.0,      # number of INT2 parameters (weights)
   # op_mac_X_Y: number of MAC operations, datatype X by datatype Y
-  "op_mac_FLOAT32_INT2": 1555200.0, # number of float32 x int2 MACs
-  "op_mac_INT2_INT2": 57906176.0,   # number of int2 x int2 MACs
-  "total_bops": 331157504.0,        # total number of MACs normalized to bit-ops (BOPS)
+  # scaled integer datatypes have a tensor- or channelwise scale factor
+  "op_mac_SCALEDINT<8>_INT2": 1345500.0, # number of scaled int8 x int2 MACs
+  "op_mac_INT2_INT2": 35615771.0,   # number of int2 x int2 MACs
+  "total_bops": 163991084.0,        # total number of MACs normalized to bit-ops (BOPS)
   "total_mem_o_bits": 4563264.0,    # total number of bits for layer outputs
-  "total_mem_w_bits": 2289024.0,    # total number of bits for layer parameters
+  "total_mem_w_bits": 1816066.0,    # total number of bits for layer parameters
   "unsupported": "set()"
 }
 ```

--- a/src/qonnx/core/datatype.py
+++ b/src/qonnx/core/datatype.py
@@ -307,6 +307,42 @@ class FixedPointType(IntType):
         return "FIXED<%d,%d>" % (self.bitwidth(), self.int_bits())
 
 
+class ScaledIntType(IntType):
+    # scaled integer datatype, only intended for
+    # inference cost calculations, many of the
+    # member methods are not implemented
+    def __init__(self, bitwidth):
+        super().__init__(bitwidth=bitwidth, signed=True)
+
+    def min(self):
+        raise Exception("Undefined for ScaledIntType")
+
+    def max(self):
+        raise Exception("Undefined for ScaledIntType")
+
+    def allowed(self, value):
+        raise Exception("Undefined for ScaledIntType")
+
+    def is_integer(self):
+        return False
+
+    def is_fixed_point(self):
+        return False
+
+    def get_hls_datatype_str(self):
+        raise Exception("Undefined for ScaledIntType")
+
+    def to_numpy_dt(self):
+        return np.float32
+
+    def signed(self):
+        "Returns whether this DataType can represent negative numbers."
+        return True
+
+    def get_canonical_name(self):
+        return "SCALEDINT<%d>" % (self.bitwidth())
+
+
 def resolve_datatype(name):
     _special_types = {
         "BINARY": IntType(1, False),
@@ -329,6 +365,12 @@ def resolve_datatype(name):
         bitwidth = int(nums[0].strip())
         intwidth = int(nums[1].strip())
         return FixedPointType(bitwidth, intwidth)
+    elif name.startswith("SCALEDINT"):
+        name = name.replace("SCALEDINT<", "")
+        name = name.replace(">", "")
+        nums = name.split(",")
+        bitwidth = int(nums[0].strip())
+        return ScaledIntType(bitwidth)
     else:
         raise KeyError("Could not resolve DataType " + name)
 

--- a/src/qonnx/custom_op/general/quant.py
+++ b/src/qonnx/custom_op/general/quant.py
@@ -188,6 +188,12 @@ class Quant(CustomOp):
                 finn_dt = DataType["UINT" + str(bit_width)]
         return finn_dt
 
+    def get_scaled_integer_datatype(self, model):
+        bit_width = model.get_initializer(self.onnx_node.input[3])
+        bit_width = int(bit_width)
+        finn_dt = DataType["SCALEDINT<%d>" % (bit_width)]
+        return finn_dt
+
     def get_output_dtype(self, model):
         node = self.onnx_node
         # scale, zero-point and bitwidth must be read from initializers
@@ -209,8 +215,7 @@ class Quant(CustomOp):
         if unit_scale and zero_zeropt:
             finn_dt = self.get_integer_datatype(model)
         else:
-            finn_dt = DataType["FLOAT32"]
-
+            finn_dt = self.get_scaled_integer_datatype(model)
         return finn_dt
 
     def infer_node_datatype(self, model):

--- a/src/qonnx/util/inference_cost.py
+++ b/src/qonnx/util/inference_cost.py
@@ -88,7 +88,7 @@ def inference_cost(model_filename, *, output_json=None, output_onnx=None, prepro
         model = model.transform(InferShapes())
         model = model.transform(GiveUniqueParameterTensors())
         model = model.transform(InferDataTypes())
-        model = model.transform(FoldConstants())
+        model = model.transform(FoldConstants(exclude_op_types=[]))
         model = model.transform(RemoveUnusedTensors())
         model = model.transform(RemoveStaticGraphInputs())
         model = model.transform(InferDataTypes())
@@ -111,6 +111,8 @@ def inference_cost(model_filename, *, output_json=None, output_onnx=None, prepro
     if output_json is not None:
         with open(output_json, "w") as f:
             json.dump(ret, f, sort_keys=True, indent=2)
+
+    return ret
 
 
 def main():

--- a/src/qonnx/util/inference_cost.py
+++ b/src/qonnx/util/inference_cost.py
@@ -67,7 +67,7 @@ def compute_mem_bits(inf_cost_dict, filter_string="mem_w"):
 
 
 def inference_cost(model_filename, *, output_json=None, output_onnx=None, preprocess=True, discount_sparsity=True):
-    """Print the inference cost estimate metric for given ONNX model.
+    """Return the inference cost estimate metric for given ONNX model.
     Supports the Quant op for weight/activation quantization.
 
     :param model_filename: Filename for ONNX model
@@ -79,7 +79,6 @@ def inference_cost(model_filename, *, output_json=None, output_onnx=None, prepro
     :param discount_sparsity: If set, will discount op cost of MAC ops with a
         constant zero weight, and the mem cost of constant zero weights.
     """
-    print("Inference cost for " + model_filename)
     model = ModelWrapper(model_filename)
     if preprocess:
         qnt_nodes = model.get_nodes_by_op_type("Quant")
@@ -106,7 +105,6 @@ def inference_cost(model_filename, *, output_json=None, output_onnx=None, prepro
 
     if "unsupported" in ret:
         ret["unsupported"] = str(ret["unsupported"])
-    print(json.dumps(ret, sort_keys=True, indent=2))
 
     if output_json is not None:
         with open(output_json, "w") as f:

--- a/tests/analysis/test_inference_cost.py
+++ b/tests/analysis/test_inference_cost.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2023 Advanced Micro Devices, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of Xilinx nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import pytest
+
+import urllib.request
+
+from qonnx.util.cleanup import cleanup
+from qonnx.util.inference_cost import inference_cost
+
+model_details = {
+    "FINN-CNV_W2A2": {
+        "url": (
+            "https://raw.githubusercontent.com/fastmachinelearning/"
+            "QONNX_model_zoo/main/models/CIFAR10/Brevitas_FINN_CNV/CNV_2W2A.onnx"
+        ),
+        "input_shape": (1, 3, 32, 32),
+        "input_range": (-1, +1),
+        "layout_sensitive": True,
+    },
+    "FINN-TFC_W2A2": {
+        "url": (
+            "https://github.com/fastmachinelearning/QONNX_model_zoo/"
+            "raw/main/models/MNIST/Brevitas_FINN_TFC/TFC/TFC_2W2A.onnx"
+        ),
+        "input_shape": (1, 1, 28, 28),
+        "input_range": (-1, +1),
+        "layout_sensitive": False,
+    },
+    "RadioML_VGG10": {
+        "url": (
+            "https://github.com/Xilinx/brevitas-radioml-challenge-21/raw/"
+            "9eef6a2417d6a0c078bfcc3a4dc95033739c5550/sandbox/notebooks/models/pretrained_VGG10_w8a8_20_export.onnx"
+        ),
+        "input_shape": (1, 2, 1024),
+        "input_range": (-1, +1),
+        "layout_sensitive": True,
+    },
+    "Conv_bias_example": {
+        "url": "https://zenodo.org/record/7626922/files/super_resolution.onnx",
+        "input_shape": (1, 1, 28, 28),
+        "input_range": (-1, +1),
+        "layout_sensitive": True,
+    },
+}
+
+
+def download_model(test_model):
+    qonnx_url = model_details[test_model]["url"]
+    # download test data
+    dl_dir = "/tmp"
+    dl_file = dl_dir + f"/{test_model}.onnx"
+    urllib.request.urlretrieve(qonnx_url, dl_file)
+    # run cleanup with default settings
+    out_file = dl_dir + f"/{test_model}_clean.onnx"
+    cleanup(dl_file, out_file=out_file)
+    return out_file
+
+
+@pytest.mark.parametrize("test_model", model_details.keys())
+def test_inference_cost(test_model):
+    # Download an clean model
+    onnx_file = download_model(test_model)
+    ret = inference_cost(onnx_file)
+    assert ret is not None


### PR DESCRIPTION
- Introduce scaled integer datatypes that indicate a tensor contains scaled integers (with either tensor-wise or channel-wise scaling factors) e.g. `SCALED_INT<4>` indicates a 4-bit scaled integer. 
- The datatype inference for `Quant` layers that have nonzero zero-point or non-unit scale now marks them as scaled integers instead of defaulting to `FLOAT32`.
- The scale factors themselves are not included as part of the datatype since this would make them too verbose. Thus, these datatype are intended to be used in inference cost measurement only for now.
- When running the inference cost utility, execute `FoldConstants(exclude_op_types=[])` to get quantized weights in initializer form, thus correctly accounting for sparsity (see discussion in #49 )

See #51 for the full discussion.