### PR TITLE
Pin onnxruntime and tensorflow dependencies to more recent versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
       - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ install_requires =
     bitstring>=3.1.7
     numpy==1.24.1
     onnx==1.13.0
-    onnxruntime==1.11.1
+    onnxruntime==1.15.0
     sigtools==2.0.3
     toposort==1.7.0
 
@@ -69,7 +69,7 @@ exclude =
 qkeras =
     pyparsing
     tf2onnx>=1.12.1
-    tensorflow==2.7.0
+    tensorflow==2.9.0
     QKeras==0.9.0
 
 # Add here test requirements (semicolon/line-separated)


### PR DESCRIPTION
This solves a dependency resolution issue preventing from installing qonnx on python 3.10, see #57. Pinning tensorflow to version 2.9.0 is necessary for python 3.10 compatibility as well. Pinning tensorflow to a more recent version, however, is not possible as it causes some tests to fail.