### PR TITLE
Better opset selection for MergeONNXModels

### DIFF
--- a/src/qonnx/custom_op/general/maxpoolnhwc.py
+++ b/src/qonnx/custom_op/general/maxpoolnhwc.py
@@ -97,7 +97,10 @@ class MaxPoolNHWC(CustomOp):
         inp_vi = helper.make_tensor_value_info(inp_name, TensorProto.FLOAT, inp.shape)
         out_vi = helper.make_tensor_value_info(out_name, TensorProto.FLOAT, dummy_out.shape)
         tmp_graph = helper.make_graph(nodes=[node], name="tmp_graph", inputs=[inp_vi], outputs=[out_vi])
-        tmp_model = qonnx_make_model(tmp_graph, producer_name="finn")
+        opset_version = self.onnx_opset_version
+        opset_imports = [helper.make_opsetid("", opset_version)]
+        onnx_kwargs = {"opset_imports": opset_imports}
+        tmp_model = qonnx_make_model(tmp_graph, producer_name="finn", **onnx_kwargs)
         tmp_model = ModelWrapper(tmp_model)
         new_ctx = {inp_name: inp}
         from qonnx.core.onnx_exec import execute_onnx

--- a/src/qonnx/custom_op/general/quantavgpool2d.py
+++ b/src/qonnx/custom_op/general/quantavgpool2d.py
@@ -131,7 +131,11 @@ class QuantAvgPool2d(CustomOp):
             inputs=[inp],
             outputs=[outp],
         )
-        model_avgpool = qonnx_make_model(graph_avgpool)
+
+        opset_version = self.onnx_opset_version
+        opset_imports = [helper.make_opsetid("", opset_version)]
+        onnx_kwargs = {"opset_imports": opset_imports}
+        model_avgpool = qonnx_make_model(graph_avgpool, **onnx_kwargs)
         idict = {node.input[0]: inp_values}
         sess = rt.InferenceSession(model_avgpool.SerializeToString())
         result_temp = sess.run(None, idict)

--- a/tests/transformation/test_merge_onnx_models.py
+++ b/tests/transformation/test_merge_onnx_models.py
@@ -73,7 +73,8 @@ def test_merge_onnx_models():
         value_info=[a0, a1],
     )
 
-    model2 = qonnx_make_model(graph, producer_name="model2")
+    exp_opset_id = 13
+    model2 = qonnx_make_model(graph, producer_name="model2", opset_imports=[helper.make_opsetid("", exp_opset_id)])
     model2 = ModelWrapper(model2)
     # initialize model2
     a0_value = np.random.uniform(low=0, high=1, size=(1)).astype(np.float32)
@@ -122,3 +123,5 @@ def test_merge_onnx_models():
 
     # check if finn datatype of graph.input[0] is still set to UINT8
     assert model_transformed.get_tensor_datatype("global_in") == DataType["UINT8"]
+    # check that the merged model uses the greater of the two input opsets
+    assert model_transformed.model.opset_import[0].version == exp_opset_id


### PR DESCRIPTION
When merging two ONNX models, the `MergeONNXModels` transformation currently defaults to the default opset version returned by the utility function `get_preferred_onnx_opset()`. This can lead to invalid output graphs if e.g. one of the input graphs is using an opset which is greater than the preferred opset. This PR introduces a testcase to catch this behavior, and a fix to `MergeONNXModels` that makes it pick the greater opset of the two input models when producing the output (and issuing a warning in the process).