### PR TITLE
Bump clize to 5.0.1 and sigtools to 4.0.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,13 +45,13 @@ package_dir =
 # For more information, check out https://semver.org/.
 install_requires =
     importlib-metadata; python_version<"3.8"
-    clize==4.1.1
+    clize==5.0.1
     protobuf==3.20.3
     bitstring>=3.1.7
     numpy==1.24.1
     onnx==1.13.0
     onnxruntime==1.15.0
-    sigtools==2.0.3
+    sigtools==4.0.1
     toposort==1.7.0
 
 


### PR DESCRIPTION
Bump clize and sigtools version up to avoid attr error: `ImportError: cannot import name 'AttrsInstance' from 'attr' (/tmp/home_dir/.local/lib/python3.10/site-packages/attr/__init__.py)`