### PR TITLE
Quant/QCDQ converter improvements

### DIFF
--- a/src/qonnx/transformation/qonnx_to_qcdq.py
+++ b/src/qonnx/transformation/qonnx_to_qcdq.py
@@ -127,7 +127,7 @@ class QuantToQCDQ(Transformation):
                 bitwidth = int(bitwidth_t)
                 range_min = min_int(signed, narrow, bitwidth)
                 range_max = max_int(signed, narrow, bitwidth)
-                if signed and narrow:
+                if (signed and narrow) or (bitwidth < 8):
                     new_clip_oname = model.make_new_valueinfo_name()
                     new_clip_vi = oh.make_tensor_value_info(new_clip_oname, new_dtype, ishape)
                     graph.value_info.append(new_clip_vi)

--- a/src/qonnx/transformation/qonnx_to_qcdq.py
+++ b/src/qonnx/transformation/qonnx_to_qcdq.py
@@ -35,7 +35,7 @@ from qonnx.core.modelwrapper import ModelWrapper
 from qonnx.custom_op.general.quant import max_int, min_int
 from qonnx.custom_op.registry import getCustomOp
 from qonnx.transformation.base import Transformation
-from qonnx.transformation.general import RemoveUnusedTensors
+from qonnx.transformation.general import MovePadAttributeToTensor, RemoveUnusedTensors
 
 
 class QuantToQCDQ(Transformation):
@@ -74,7 +74,7 @@ class QuantToQCDQ(Transformation):
                 if zeropt_t is None or zeropt_t != 0:
                     warn("Zeropoint is undefined or nonzero, skipping " + node.name)
                     continue
-                if scale_t is None or (scale_t.ndim not in [0, 1]):
+                if scale_t is None or (scale_t.squeeze().ndim not in [0, 1]):
                     warn("Scale is undefined or non-0/1D, skipping " + node.name)
                     continue
                 if bitwidth_tname is None or bitwidth_t.ndim != 0:
@@ -87,20 +87,38 @@ class QuantToQCDQ(Transformation):
                     warn("Rounding mode is not ROUND, skipping " + node.name)
                     continue
                 graph_modified = True
+                # QuantizeLinear wants 1D scale so squeeze
+                q_scale = model.get_initializer(scale_tname)
+                q_scale_new = q_scale.squeeze()
+                model.set_initializer(scale_tname, q_scale_new)
+                # resolve the scale factor axis
+                if q_scale_new.ndim == 1:
+                    qnt_axis = q_scale.shape.index(q_scale_new.shape[0])
+                else:
+                    qnt_axis = None
                 # create new zeropoint tensor with appropriate dtype
                 new_dtype = TensorProto.INT8 if signed else TensorProto.UINT8
                 new_dtype_np = np.int8 if signed else np.uint8
                 new_zeropt_name = model.make_new_valueinfo_name()
                 new_zeropt_vi = oh.make_tensor_value_info(new_zeropt_name, new_dtype, scale_t.shape)
-                new_zeropt_t = np.asarray(0, dtype=new_dtype_np)
+                new_zeropt_t = np.zeros_like(q_scale_new, dtype=new_dtype_np)
                 graph.value_info.append(new_zeropt_vi)
                 model.set_initializer(new_zeropt_name, new_zeropt_t)
                 new_qout_name = model.make_new_valueinfo_name()
                 ishape = model.get_tensor_shape(inp_tname)
                 new_qout_vi = oh.make_tensor_value_info(new_qout_name, new_dtype, ishape)
                 graph.value_info.append(new_qout_vi)
+                n_ql = len(model.get_nodes_by_op_type("QuantizeLinear"))
+                n_cl = len(model.get_nodes_by_op_type("Clip"))
+                n_dql = len(model.get_nodes_by_op_type("DequantizeLinear"))
                 # create the QuantizeLinear node
-                new_node_qnt = oh.make_node("QuantizeLinear", [inp_tname, scale_tname, new_zeropt_name], [new_qout_name])
+                new_node_qnt = oh.make_node(
+                    "QuantizeLinear",
+                    [inp_tname, scale_tname, new_zeropt_name],
+                    [new_qout_name],
+                    name="QuantizeLinear_%d" % (n_ql + 1),
+                    axis=qnt_axis,
+                )
                 graph.node.insert(model.get_node_index(last_node) + 1, new_node_qnt)
                 last_out_tname = new_qout_name
                 last_node = new_node_qnt
@@ -121,13 +139,19 @@ class QuantToQCDQ(Transformation):
                     new_clip_max = model.make_new_valueinfo_name()
                     new_clip_max_t = np.asarray(range_max, dtype=new_dtype_np)
                     model.set_initializer(new_clip_max, new_clip_max_t)
-                    new_node_clip = oh.make_node("Clip", [last_out_tname, new_clip_min, new_clip_max], [new_clip_oname])
+                    new_node_clip = oh.make_node(
+                        "Clip", [last_out_tname, new_clip_min, new_clip_max], [new_clip_oname], name="Clip_%d" % (n_cl + 1)
+                    )
                     last_out_tname = new_clip_oname
                     graph.node.insert(model.get_node_index(last_node) + 1, new_node_clip)
                     last_node = new_node_clip
                 # finally add the DequantizeLinear node
                 new_node_deqnt = oh.make_node(
-                    "DequantizeLinear", [last_out_tname, scale_tname, new_zeropt_name], [out_tname]
+                    "DequantizeLinear",
+                    [last_out_tname, scale_tname, new_zeropt_name],
+                    [out_tname],
+                    name="DequantizeLinear_%d" % (n_dql + 1),
+                    axis=qnt_axis,
                 )
                 graph.node.insert(model.get_node_index(last_node) + 1, new_node_deqnt)
                 last_node = new_node_deqnt
@@ -146,5 +170,7 @@ class QuantToQCDQ(Transformation):
                 )
                 warn("Forcing opset version %s upgrade to ensure valid ONNX" % clip_min_opset)
                 model.model.opset_import[0].version = clip_min_opset
+                # ensure new Pad node requirements are respected
+                model = model.transform(MovePadAttributeToTensor())
 
         return (model, graph_modified)

--- a/src/qonnx/util/cleanup.py
+++ b/src/qonnx/util/cleanup.py
@@ -56,8 +56,7 @@ def cleanup(in_file, *, preserve_qnt_ops=True, out_file=None, override_batchsize
     """Execute a set of graph transformations to clean-up the given ONNX file.
 
     :param in_file: Filename for the input ONNX model
-    :param preserve_qnt_ops (default True): If set, do not const-fold quantization operators
-        (to preserve weight quantizer information)
+    :param preserve_qnt_ops: Preserve weight quantization operators
     :param out_file: If set, filename for the output ONNX model. Set to in_file with _clean
         suffix otherwise.
     :param override_batchsize: If specified, override the batch size for the ONNX graph

--- a/src/qonnx/util/convert.py
+++ b/src/qonnx/util/convert.py
@@ -29,23 +29,37 @@
 import clize
 
 from qonnx.core.modelwrapper import ModelWrapper
+from qonnx.transformation.qcdq_to_qonnx import QCDQToQuant
 from qonnx.transformation.qonnx_to_qcdq import QuantToQCDQ
 
+CONVERT_MODE_QCDQ = "qcdq"
+CONVERT_MODE_QUANT = "quant"
 
-def convert(input_model_file, output_style: str = "qcdq", output_file: str = None):
+convert_modes = {CONVERT_MODE_QCDQ, CONVERT_MODE_QUANT}
+
+convert_mode_options = clize.parameters.mapped(
+    [
+        (CONVERT_MODE_QCDQ, [CONVERT_MODE_QCDQ], "Convert from Quant to QCDQ"),
+        (CONVERT_MODE_QUANT, [CONVERT_MODE_QUANT], "Convert from QCDQ to Quant"),
+    ]
+)
+
+
+def convert(input_model_file, *, output_style: convert_mode_options, output_file: str = None):
     """Convert an ONNX file from one style of quantization to another, where possible.
-    Currently, the input model must be QONNX (Quant nodes) and only QCDQ is supported
-    as the conversion target. Please see the documentation on the QuantToQCDQ
-    transformation to learn more about the particular limitations.
+    Please see the documentation on the QuantToQCDQ and QCDQToQuant
+    transformations to learn more about the particular limitations.
 
     :param input_model_file: Filename for the input ONNX model.
-    :param output_style: Quantization style for the output. Currently only 'qcdq'
+    :param output_style: Quantization style for the output.
     :param output_file: If specified, write the output ONNX model to this filename.
         Otherwise, will default to the input file with an _output_style suffix.
     """
     model = ModelWrapper(input_model_file)
-    if output_style == "qcdq":
+    if output_style == CONVERT_MODE_QCDQ:
         model = model.transform(QuantToQCDQ())
+    elif output_style == CONVERT_MODE_QUANT:
+        model = model.transform(QCDQToQuant())
     else:
         print("Unknown output_style for conversion: %s" % output_style)
         exit(-1)

--- a/tests/transformation/test_qonnx_to_qcdq.py
+++ b/tests/transformation/test_qonnx_to_qcdq.py
@@ -62,7 +62,7 @@ qonnxtoqcdq_details = {
         # 18 bit bias quant not convertible to QCDQ
         "nonconvertible_quant": 1,
         "exp_qdq_nodes": 55,
-        "exp_clip_nodes": 28,
+        "exp_clip_nodes": 55,
     },
 }
 
@@ -73,8 +73,6 @@ model_details = {**model_details, **qonnxtoqcdq_details}
 
 @pytest.mark.parametrize("test_model", model_details.keys())
 def test_qonnx_to_qcdq_to_qonnx(test_model):
-    if test_model == "MobileNetv1-w4a4":
-        pytest.xfail("Known problem in MNv1 conversion")
     test_details = model_details[test_model]
     dl_file = download_model(test_model=test_model)
     assert os.path.isfile(dl_file)

--- a/tests/transformation/test_qonnx_to_qcdq.py
+++ b/tests/transformation/test_qonnx_to_qcdq.py
@@ -58,6 +58,12 @@ qonnxtoqcdq_details = {
         # half the Quants don't need Clip (not signed narrow)
         "exp_clip_nodes": 10,
     },
+    "MobileNetv1-w4a4": {
+        # 18 bit bias quant not convertible to QCDQ
+        "nonconvertible_quant": 1,
+        "exp_qdq_nodes": 55,
+        "exp_clip_nodes": 28,
+    },
 }
 
 # inherit basics for matching testcases from test util
@@ -67,6 +73,8 @@ model_details = {**model_details, **qonnxtoqcdq_details}
 
 @pytest.mark.parametrize("test_model", model_details.keys())
 def test_qonnx_to_qcdq_to_qonnx(test_model):
+    if test_model == "MobileNetv1-w4a4":
+        pytest.xfail("Known problem in MNv1 conversion")
     test_details = model_details[test_model]
     dl_file = download_model(test_model=test_model)
     assert os.path.isfile(dl_file)


### PR DESCRIPTION
- Respect differences in how `Quant` and `(De)QuantizeLinear` prefer their scale factors, the latter prefers squeezed 1D and specifies and axis argument. This PR fixes the conversion behavior for both `QuantToQCDQ` and `QCDQToQuant`
- Include MobileNetv1-w4a4 from the model zoo as part of the conversion tests