### PR TITLE
Fix: Adding dropped attributes to transposed convolution op

### DIFF
--- a/src/qonnx/transformation/subpixel_to_deconv.py
+++ b/src/qonnx/transformation/subpixel_to_deconv.py
@@ -205,6 +205,8 @@ class SubPixelToDeconvolution(Transformation):
                         kernel_shape=[kh_size_deconv, kw_size_deconv],
                         strides=[block_size, block_size],
                         pads=deconv_pad,
+                        group=group,
+                        dilations=dilation,
                     )
                     W_deconv_init = weight_name
                     if weight_prod is not None:

--- a/tests/transformation/test_subpixel_to_deconv.py
+++ b/tests/transformation/test_subpixel_to_deconv.py
@@ -83,7 +83,6 @@ def test_subpixel_to_deconv_quant_espcn():
     output_subpixel_conv = oxe.execute_onnx(model, input_dict)[oname]
     # translate the sub-pixel convolution to the deconvolution
     new_model = model.transform(SubPixelToDeconvolution())
-    new_model = new_model.transform(InferShapes())
     # check that there are no DepthToSpace ops left
     op_types = list(map(lambda x: x.op_type, new_model.graph.node))
     assert "DepthToSpace" not in op_types, "Error: the DepthToSpace nodes would be removed."


### PR DESCRIPTION
- [x] Adding `group` and `dilations` to the transposed convolution op in `SubPixelToDeconvolution`
- [x] Removing unused transformation in the unit test 