### PR TITLE
Add extra conv lowering tests + fix linter issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: '^docs/conf.py'
 
 default_language_version:
-    python: python3.8
+    python: python3.10
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -29,7 +29,7 @@ repos:
   rev: 23.1.0
   hooks:
   - id: black
-    language_version: python3
+    language_version: python3.10
     args: [--line-length=125]
 
 - repo: https://github.com/PyCQA/flake8

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ git clone https://github.com/fastmachinelearning/qonnx
 cd qonnx
 virtualenv -p python3.8 venv
 source venv/bin/activate
-pip install -e .[qkeras,testing,docs]
+pip install -e .[qkeras,testing]
 ```
 
 Run entire test suite, parallelized across CPU cores:

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ install_requires =
     bitstring>=3.1.7
     numpy>=1.24.1
     onnx>=1.13.0
-    onnxruntime>=1.15.0
+    onnxruntime>=1.16.1
     sigtools>=4.0.1
     toposort>=1.7.0
 

--- a/tests/transformation/test_expose_intermediate.py
+++ b/tests/transformation/test_expose_intermediate.py
@@ -51,5 +51,4 @@ def test_expose_intermediate(model_name):
     # break out all dynamic (non-weight) quantizer outputs
     pattern_list = ["Quant"]
     model = model.transform(ExposeIntermediateTensorsPatternList(pattern_list, dynamic_only=True))
-    model.save(model_name + "_dbg.onnx")
     assert len(model.graph.output) == model_details_expint[model_name]["n_quant_outputs"] + 1


### PR DESCRIPTION
Clean up conv lowering test infratructure by refactoring into helper function + add new testcase for rectangular depthwise dilated convolutions.

Also fixes two infrastructure issues: 
* pre-commit / black temporarily by switching to python3.10 for linter: https://github.com/pypa/pip/issues/11294
* use onnxrt>=1.16.1 to avoid onnxrt issue: https://github.com/microsoft/onnxruntime/issues/17631