### PR TITLE
Restrict onnx version to <1.15.0 to fix failing keras tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ install_requires =
     protobuf==3.20.3
     bitstring>=3.1.7
     numpy>=1.24.1
-    onnx>=1.13.0
+    onnx>=1.13.0,<1.15.0
     onnxruntime>=1.16.1
     sigtools>=4.0.1
     toposort>=1.7.0


### PR DESCRIPTION
Recently, some test cases from` tests/keras/test_keras_convert.py` started failing for apparently no reason. This is an issue in some updated dependencies which are not pinned exactly. Looks like it is this one in tf2onnx: https://github.com/onnx/tensorflow-onnx/issues/2262

For now, the proposed fix is to restrict the version of the onnx dependency to <1.15.0, just as discussed in the referenced issue.