### PR TITLE
Allow for no explicit pads in Conv layer in channel last conversion

### DIFF
--- a/src/qonnx/custom_op/channels_last/conv.py
+++ b/src/qonnx/custom_op/channels_last/conv.py
@@ -54,7 +54,7 @@ class Conv(ChannelsLastWrappedOp):
             "dilations": ("ints", True, []),
             # amount of padding to be inserted before/after each non-dummy spatial dim
             # i.e. [H_begin, W_begin, H_end, W_end]
-            "pads": ("ints", True, [0, 0, 0, 0]),  # default: no padding
+            "pads": ("ints", False, [0, 0, 0, 0]),  # default: no padding
             "group": ("i", True, 1),
         }
 


### PR DESCRIPTION
It seems like pads should default to zero in a conv layer if it's not set and auto_pads is either not set or set to 'NOTSET'. It seems like we currently don't support auto_pads during the channel last conversion--should we? This PR fixes the case when pads is not set, treating it as if it's all zeros.