### PR TITLE
Make gen_finn_dt_tensor consider the numpy type for INT and FIXED types

### DIFF
--- a/src/qonnx/util/basic.py
+++ b/src/qonnx/util/basic.py
@@ -228,10 +228,12 @@ def gen_finn_dt_tensor(finn_dt, tensor_shape):
     elif finn_dt == DataType["BINARY"]:
         tensor_values = np.random.randint(2, size=tensor_shape)
     elif "INT" in finn_dt.name or finn_dt == DataType["TERNARY"]:
-        tensor_values = np.random.randint(finn_dt.min(), high=finn_dt.max() + 1, size=tensor_shape)
+        tensor_values = np.random.randint(
+            finn_dt.min(), high=finn_dt.max() + 1, size=tensor_shape, dtype=finn_dt.to_numpy_dt()
+        )
     elif "FIXED" in finn_dt.name:
         int_dt = DataType["INT" + str(finn_dt.bitwidth())]
-        tensor_values = np.random.randint(int_dt.min(), high=int_dt.max() + 1, size=tensor_shape)
+        tensor_values = np.random.randint(int_dt.min(), high=int_dt.max() + 1, size=tensor_shape, dtype=int_dt.to_numpy_dt())
         tensor_values = tensor_values * finn_dt.scale_factor()
     elif finn_dt == DataType["FLOAT32"]:
         tensor_values = np.random.randn(*tensor_shape)


### PR DESCRIPTION
When the FINN datatype is, for example, `UINT64`, `np.random.randint` still implicitly defaults to `np.int64`, making the `high=finn_dt.max() + 1` exceed the valid range: `ValueError: high is out of bounds for int64`. This happened to me in the `step_make_pynq_driver` of a FINN build of a `Gather`/`Lookup` node where the index input has been annotated to `UINT64`.

I think, the most generic solution to this is specifying the numpy datatype corresponding to the FINN datatype as an additional `dtype=` argument to the function call. I am not sure whether it makes sense to add this to all the other cases as well, i.e., to BINARY, BIPOLAR and FLOAT32.