### PR TITLE
add type check for input name of resolve_datatype()

### DIFF
--- a/src/qonnx/core/datatype.py
+++ b/src/qonnx/core/datatype.py
@@ -376,7 +376,6 @@ class ScaledIntType(IntType):
 
 
 def resolve_datatype(name):
-
     if not isinstance(name, str):
         raise TypeError(f"Input 'name' must be of type 'str', but got type '{type(name).__name__}'")
 

--- a/src/qonnx/core/datatype.py
+++ b/src/qonnx/core/datatype.py
@@ -376,6 +376,10 @@ class ScaledIntType(IntType):
 
 
 def resolve_datatype(name):
+
+    if not isinstance(name, str):
+        raise TypeError(f"Input 'name' must be of type 'str', but got type '{type(name).__name__}'")
+
     _special_types = {
         "BINARY": IntType(1, False),
         "BIPOLAR": BipolarType(),

--- a/tests/core/test_datatypes.py
+++ b/tests/core/test_datatypes.py
@@ -116,23 +116,35 @@ def test_resolve_datatype():
     assert resolve_datatype("INT8")
     assert resolve_datatype("INT16")
     assert resolve_datatype("INT32")
-    assert resolve_datatype("BINARY")
     assert resolve_datatype("FLOAT32")
 
 
 def test_input_type_error():
-    # test with invalid input to check if the TypeError works
-    try:
-        resolve_datatype(123)  # This should raise a TypeError
-    except TypeError as e:
-        pass
-    else:
-        print("Test with invalid input failed: No TypeError was raised.")
 
-    # test with invalid input to check if the TypeError works
-    try:
-        resolve_datatype(1.23)  # This should raise a TypeError
-    except TypeError as e:
-        pass
-    else:
-        print("Test with invalid input failed: No TypeError was raised.")
+    def test_resolve_datatype(input):
+        # test with invalid input to check if the TypeError works
+        try:
+            resolve_datatype(input)  # This should raise a TypeError
+        except TypeError as e:
+            pass
+        else:
+            print("Test with invalid input failed: No TypeError was raised.")
+
+    test_resolve_datatype(123)
+    test_resolve_datatype(1.23)
+    test_resolve_datatype(DataType["BIPOLAR"])
+    test_resolve_datatype(DataType["BINARY"])
+    test_resolve_datatype(DataType["TERNARY"])
+    test_resolve_datatype(DataType["UINT2"])
+    test_resolve_datatype(DataType["UINT3"])
+    test_resolve_datatype(DataType["UINT4"])
+    test_resolve_datatype(DataType["UINT8"])
+    test_resolve_datatype(DataType["UINT16"])
+    test_resolve_datatype(DataType["UINT32"])
+    test_resolve_datatype(DataType["INT2"])
+    test_resolve_datatype(DataType["INT3"])
+    test_resolve_datatype(DataType["INT4"])
+    test_resolve_datatype(DataType["INT8"])
+    test_resolve_datatype(DataType["INT16"])
+    test_resolve_datatype(DataType["INT32"])
+    test_resolve_datatype(DataType["FLOAT32"])

--- a/tests/core/test_datatypes.py
+++ b/tests/core/test_datatypes.py
@@ -29,6 +29,7 @@
 import numpy as np
 
 from qonnx.core.datatype import DataType
+from qonnx.core.datatype import resolve_datatype
 
 
 def test_datatypes():
@@ -97,3 +98,41 @@ def test_smallest_possible():
     assert DataType.get_smallest_possible(-1) == DataType["BIPOLAR"]
     assert DataType.get_smallest_possible(-3) == DataType["INT3"]
     assert DataType.get_smallest_possible(-3.2) == DataType["FLOAT32"]
+
+
+def test_resolve_datatype():
+    assert resolve_datatype("BIPOLAR")
+    assert resolve_datatype("BINARY")
+    assert resolve_datatype("TERNARY")
+    assert resolve_datatype("UINT2")
+    assert resolve_datatype("UINT3")
+    assert resolve_datatype("UINT4")
+    assert resolve_datatype("UINT8")
+    assert resolve_datatype("UINT16")
+    assert resolve_datatype("UINT32")
+    assert resolve_datatype("INT2")
+    assert resolve_datatype("INT3")
+    assert resolve_datatype("INT4")
+    assert resolve_datatype("INT8")
+    assert resolve_datatype("INT16")
+    assert resolve_datatype("INT32")
+    assert resolve_datatype("BINARY")
+    assert resolve_datatype("FLOAT32")
+
+
+def test_input_type_error():
+    # test with invalid input to check if the TypeError works
+    try:
+        resolve_datatype(123)  # This should raise a TypeError
+    except TypeError as e:
+        pass
+    else:
+        print("Test with invalid input failed: No TypeError was raised.")
+
+    # test with invalid input to check if the TypeError works
+    try:
+        resolve_datatype(1.23)  # This should raise a TypeError
+    except TypeError as e:
+        pass
+    else:
+        print("Test with invalid input failed: No TypeError was raised.")

--- a/tests/core/test_datatypes.py
+++ b/tests/core/test_datatypes.py
@@ -28,8 +28,7 @@
 
 import numpy as np
 
-from qonnx.core.datatype import DataType
-from qonnx.core.datatype import resolve_datatype
+from qonnx.core.datatype import DataType, resolve_datatype
 
 
 def test_datatypes():
@@ -120,12 +119,11 @@ def test_resolve_datatype():
 
 
 def test_input_type_error():
-
     def test_resolve_datatype(input):
         # test with invalid input to check if the TypeError works
         try:
             resolve_datatype(input)  # This should raise a TypeError
-        except TypeError as e:
+        except TypeError:
             pass
         else:
             print("Test with invalid input failed: No TypeError was raised.")

--- a/tests/core/test_datatypes.py
+++ b/tests/core/test_datatypes.py
@@ -126,7 +126,7 @@ def test_input_type_error():
         except TypeError:
             pass
         else:
-            print("Test with invalid input failed: No TypeError was raised.")
+            assert False, "Test with invalid input failed: No TypeError was raised."
 
     test_resolve_datatype(123)
     test_resolve_datatype(1.23)


### PR DESCRIPTION
I found some potential issue in the `resolve_datatype()` function of the `datatype.py` file:

```python
def resolve_datatype(name):
    _special_types = {
        "BINARY": IntType(1, False),
        "BIPOLAR": BipolarType(),
        "TERNARY": TernaryType(),
        "FLOAT32": FloatType(),
        "FLOAT16": Float16Type(),
    }
    if name in _special_types.keys():
        return _special_types[name]
    elif name.startswith("UINT"):
        bitwidth = int(name.replace("UINT", ""))
        return IntType(bitwidth, False)
    elif name.startswith("INT"):
    ...
 ```
 
Looking at this function I first thought one has to pass a string for the name input. However, if the input `name` is of type for example `qonnx.core.datatype.BipolarType` with a name attribute which is covered in the `_spacial_types` dictonary (in this case Bipolar) the check `if name in _special_types.keys():` will be true. But when you pass for example an `qonnx.core.datatype.IntType` class the check `if name in _special_types.keys():` will be false and the program will crash at the next check `elif name.startswith("UINT"):` since here the assumption is that the input `name` is of type `str`. So long story short the first `if` can accept a `str` or a class which is named in the `_spacial_types` dictonary while the other cases only work with `str`.

I propose to introduce a type check for the input `name` for a better error handling. I also added a test case to check if the error is raised and another one to test the `resolve_datatype` function.