### PR TITLE
Handle ExtractConvBias properly and remove unused bias Quant nodes

### DIFF
--- a/src/qonnx/transformation/extract_conv_bias.py
+++ b/src/qonnx/transformation/extract_conv_bias.py
@@ -45,24 +45,15 @@ class ExtractBiasFromConv(Transformation):
                     # Extract bias
                     bias = model.get_initializer(n.input[2])
                     if bias is None:
-                        name = n.input[2]
-                        name = name.replace("out", "param")
-                        bias = model.get_initializer(name)
+                        producer = model.find_producer(n.input[2])
+                        bias = model.get_initializer(producer.input[0])
                         if bias is None:
                             warnings.warn(f"Could not extract bias from node")
                             continue
 
-                    # Find the node that provides this input
-                    bias_input_name = n.input[2]
-                    producer_node = None
-                    for pn in graph.node:
-                        if bias_input_name in pn.output:
-                            producer_node = pn
-                            break
-                    
-                    if producer_node is not None:
+                    if producer is not None:
                         # Mark the producer node for removal
-                        nodes_to_remove.append(producer_node)
+                        nodes_to_remove.append(producer)
                     
                     # Insert bias as Add node behind the Conv node
                     out_shape = model.get_tensor_shape(n.output[0])


### PR DESCRIPTION
During the `ExtractBiasFromConv` transformation, sometimes the bias initializer was not found. The current code searches for the bias initializer with the name of the tensor that acts as input to the convolution node, but it should search for the initializer with the name of the first input to the Quant node that produces this tensor. For the same reason, the producer node should be deleted and not the tensor.