### PR TITLE
Add support for multiple default configurations

### DIFF
--- a/src/qonnx/transformation/general.py
+++ b/src/qonnx/transformation/general.py
@@ -340,8 +340,14 @@ class ApplyConfig(Transformation):
             used_configurations += [node.name]
 
             # set specified defaults
-            default_configs = {k: v for k, v in model_config["Defaults"].items() if k not in model_config}
-            default_configs = {k: v[0] for k, v in default_configs.items() if v[1] == "all" or node.op_type in v[1]}
+            default_values = []
+            for key, value in model_config["Defaults"].items():
+                assert (len(value) % 2 == 0)
+                if key not in model_config:
+                    for val, op in zip(value[::2], value[1::2]):
+                        default_values.append((key, val, op)) 
+                        assert (not (op == "all"  and len(value) > 2))
+            default_configs = {key: val for key, val, op in default_values if op == "all" or node.op_type in op}
             for attr, value in default_configs.items():
                 inst.set_nodeattr(attr, value)
 

--- a/src/qonnx/transformation/general.py
+++ b/src/qonnx/transformation/general.py
@@ -342,11 +342,11 @@ class ApplyConfig(Transformation):
             # set specified defaults
             default_values = []
             for key, value in model_config["Defaults"].items():
-                assert (len(value) % 2 == 0)
+                assert len(value) % 2 == 0
                 if key not in model_config:
                     for val, op in zip(value[::2], value[1::2]):
-                        default_values.append((key, val, op)) 
-                        assert (not (op == "all"  and len(value) > 2))
+                        default_values.append((key, val, op))
+                        assert not (op == "all" and len(value) > 2)
             default_configs = {key: val for key, val, op in default_values if op == "all" or node.op_type in op}
             for attr, value in default_configs.items():
                 inst.set_nodeattr(attr, value)


### PR DESCRIPTION
This PR addresses the problem of not being able to assign a default configurations of the same type for different node types. For example, one could not assign the default preferred_impl_style for node type "MVAU" as "hls" and "rtl" for node type "FMPadding" in FINN. 

An example of a specialze layer config for FINN which uses the updated parser:

```
{
    "Defaults": {
        "preferred_impl_style": ["hls", ["MVAU"], "rtl", ["FMPadding"]]    
    }
}
```


The changes made to the parser do not break old configurations. 