### PR TITLE
Add resize to change_3d_tensors_to_4d transformation

### DIFF
--- a/src/qonnx/transformation/change_3d_tensors_to_4d.py
+++ b/src/qonnx/transformation/change_3d_tensors_to_4d.py
@@ -64,6 +64,7 @@ def _find_invalid_nodes(model):
         "Reshape",
         "MaxPool",
         "Upsample",
+        "Resize",
     ]
     invalid_nodes = []
     for n in model.graph.node:
@@ -194,6 +195,42 @@ class Change3DTo4DTensors(Transformation):
                 assert list(scales.shape) == [3]
                 scales = np.append(scales, np.asarray(1.0, dtype=np.float32))
                 model.set_initializer(n.input[1], scales)
+            elif node_op_type == "Resize":
+                if len(n.input) == 2:
+                    # Resize version 10
+                    scales = model.get_initializer(n.input[1])
+                    scales = np.append(scales, np.asarray(1.0, dtype=np.float32))
+                    model.set_initializer(n.input[1], scales)
+                elif len(n.input) == 3:
+                    # Resize version 11 and up (no size input)
+                    scales = model.get_initializer(n.input[2])
+                    scales = np.append(scales, np.asarray(1.0, dtype=np.float32))
+                    model.set_initializer(n.input[2], scales)
+                elif len(n.input) == 4:
+                    scales_exists = (model.get_initializer(n.input[2]) is not None) and (len(model.get_initializer(n.input[2])) != 0)
+                    sizes_exists = (model.get_initializer(n.input[3]) is not None) and (len(model.get_initializer(n.input[3])) != 0)
+                    assert (scales_exists ^ sizes_exists), (
+                        "%s: Either scales or the target output size must " 
+                        "be specified. Specifying both is prohibited." % n.name
+                        )  
+                    if (scales_exists): 
+                        # Scales parameter is a 1d list of upsampling factors along each axis
+                        scales = model.get_initializer(n.input[2])
+                        scales = np.append(scales, np.asarray(1.0, dtype=np.float32))
+                        model.set_initializer(n.input[2], scales)
+                    else:
+                        # Size parameter is a 1d list of the target size along each axis
+                        sizes = model.get_initializer(n.input[3])
+                        sizes = np.append(sizes, np.asarray(1.0, dtype=np.int64))
+                        model.set_initializer(n.input[3], sizes)
+                if len(n.input) in (3, 4) and model.get_initializer(n.input[1]) is not None:
+                    # ROI handling
+                    roi =  model.get_initializer(n.input[1])
+                    d_type = roi.dtype #float64, float32 or float16
+                    # ROI for 3d tensor: [start1, start2, start3, end1, end2, end3]
+                    roi = np.concatenate((roi[0:3], np.asarray(1.0, dtype=d_type), roi[3:6], np.asarray(1.0, dtype=d_type)), axis=None)
+                    model.set_initializer(n.input[1], roi)
+                input_shape.append(1)
 
         # Change format of each input/value_info/output tensor
         for k, v in all_tensors.items():


### PR DESCRIPTION
This PR adds resize to the change_3d_tensors_to_4d transformation. The implementation supports resize version 10 up to 19. 

Version 10 only supports `scales` as an input, other than the input tensor. 

Version 11 up to 19 additionally support the `roi` and `sizes` inputs. `sizes` and `scales` are mutually exclusive. The Problem is that different versions have a different understanding of how to mark an input as unused. As an example: 

- Version 11 dictates: "If `sizes` is needed, the user must set `scales` to an empty tensor."
- Version 13 dictates: "If `sizes` is needed, the user can use an empty string as the name of `scales` in this operator’s input list." 

I am thus checking if `scales` or `sizes` exist by checking if they are None or are empty. None is returned by `model.get_initializer()` if the input is an empty string in the input list.