### PR TITLE
Avoiding mp.Pool in case of using only 1 worker for easier pdb debugging

### DIFF
--- a/src/qonnx/transformation/base.py
+++ b/src/qonnx/transformation/base.py
@@ -107,8 +107,14 @@ class NodeLocalTransformation(Transformation):
             old_nodes.append(model.graph.node.pop())
 
         # Execute transformation in parallel
-        with mp.Pool(self._num_workers) as p:
-            new_nodes_and_bool = p.map(self.applyNodeLocal, old_nodes, chunksize=1)
+        if self._num_workers > 1:
+            with mp.Pool(self._num_workers) as p:
+                new_nodes_and_bool = p.map(self.applyNodeLocal, old_nodes, chunksize=1)
+        # execute without mp.Pool in case of 1 worker to simplify debugging
+        else:
+            new_nodes_and_bool = [self.applyNodeLocal(node) for node in old_nodes]
+
+
 
         # extract nodes and check if the transformation needs to run again
         # Note: .pop() had initially reversed the node order

--- a/src/qonnx/transformation/base.py
+++ b/src/qonnx/transformation/base.py
@@ -114,8 +114,6 @@ class NodeLocalTransformation(Transformation):
         else:
             new_nodes_and_bool = [self.applyNodeLocal(node) for node in old_nodes]
 
-
-
         # extract nodes and check if the transformation needs to run again
         # Note: .pop() had initially reversed the node order
         run_again = False


### PR DESCRIPTION
Problem: 
When debugging QONNX model transformations which can make use of applyNodeLocal using pdb, the use of multiprocessing.Pool stops the debugger from being able to stop at the exact stack frame which is created by the process forked using the multiprocessing library if the error happened there.

The stack frame can still be accessed by breakpointing right before the actual error occurs, however this would require prior knowledge of where the code breaks, which can be highly undesirable.

Solution:
Intuitively, the user would expect that if they simply set their num_workers to 1, that multiprocessing will not be called and pdb will work as expected. Thus, I propose to simply check for this case and run the applyNodeLocal() function 'as is' without mp.Pool if the worker count is set to 1.