### PR TITLE
Preserve weight quantizer while lowering convolutions

### DIFF
--- a/src/qonnx/transformation/lower_convs_to_matmul.py
+++ b/src/qonnx/transformation/lower_convs_to_matmul.py
@@ -51,6 +51,10 @@ class LowerConvsToMatMul(Transformation):
                 warnings.warn("Found Conv node with bias, skipping")
                 continue
 
+            if model.get_initializer(node.input[1]) is None:
+                warnings.warn("Found Conv node with non-initialized weight, skipping")
+                continue
+
             # extract parameters of node
             (
                 cnv_input,

--- a/src/qonnx/util/test.py
+++ b/src/qonnx/util/test.py
@@ -145,15 +145,20 @@ def qonnx_download_model():
     clize.run(download_model)
 
 
-def get_golden_in_and_output(test_model):
-    model = download_model(test_model, do_cleanup=True, return_modelwrapper=True)
-    rng = np.random.RandomState(42)
+def get_random_input(test_model, seed=42):
+    rng = np.random.RandomState(seed)
     input_shape = test_model_details[test_model]["input_shape"]
     (low, high) = test_model_details[test_model]["input_range"]
     size = np.prod(np.asarray(input_shape))
     input_tensor = rng.uniform(low=low, high=high, size=size)
     input_tensor = input_tensor.astype(np.float32)
     input_tensor = input_tensor.reshape(input_shape)
+    return input_tensor
+
+
+def get_golden_in_and_output(test_model, seed=42):
+    model = download_model(test_model, do_cleanup=True, return_modelwrapper=True)
+    input_tensor = get_random_input(test_model, seed=seed)
     input_dict = {model.graph.input[0].name: input_tensor}
     golden_output_dict = oxe.execute_onnx(model, input_dict)
     golden_result = golden_output_dict[model.graph.output[0].name]

--- a/tests/transformation/test_conv_lowering.py
+++ b/tests/transformation/test_conv_lowering.py
@@ -43,6 +43,14 @@ from qonnx.custom_op.registry import getCustomOp
 from qonnx.transformation.infer_shapes import InferShapes
 from qonnx.transformation.lower_convs_to_matmul import LowerConvsToMatMul
 from qonnx.util.basic import gen_finn_dt_tensor, qonnx_make_model
+from qonnx.util.test import download_model
+
+
+def test_conv_lowering_quant_weights():
+    model_name = "FINN-CNV_W2A2"
+    model = download_model(model_name, return_modelwrapper=True, do_cleanup=True)
+    model = model.transform(LowerConvsToMatMul())
+    assert model.get_nodes_by_op_type("Conv") == []
 
 
 def test_conv_lowering_convmnist():

--- a/tests/transformation/test_conv_lowering.py
+++ b/tests/transformation/test_conv_lowering.py
@@ -55,7 +55,7 @@ def test_conv_lowering_quant_weights(model_name):
     input_dict = {model.graph.input[0].name: input_t}
     prod_dict = oxe.execute_onnx(model, input_dict)
     prod_t = prod_dict[model.graph.output[0].name]
-    assert (prod_t == golden_t).all()
+    assert np.isclose(prod_t, golden_t).all()
 
 
 def test_conv_lowering_convmnist():

--- a/tests/transformation/test_conv_lowering.py
+++ b/tests/transformation/test_conv_lowering.py
@@ -49,13 +49,13 @@ from qonnx.util.test import download_model, get_golden_in_and_output
 @pytest.mark.parametrize("model_name", ["FINN-CNV_W2A2", "MobileNetv1-w4a4"])
 def test_conv_lowering_quant_weights(model_name):
     model = download_model(model_name, return_modelwrapper=True, do_cleanup=True)
+    input_t, golden_t = get_golden_in_and_output(model_name, seed=0)
+    input_dict = {model.graph.input[0].name: input_t}
     model = model.transform(LowerConvsToMatMul())
     assert model.get_nodes_by_op_type("Conv") == []
-    input_t, golden_t = get_golden_in_and_output(model_name)
-    input_dict = {model.graph.input[0].name: input_t}
     prod_dict = oxe.execute_onnx(model, input_dict)
     prod_t = prod_dict[model.graph.output[0].name]
-    assert np.isclose(prod_t, golden_t).all()
+    assert np.isclose(golden_t, prod_t, atol=1e-04).all()
 
 
 def test_conv_lowering_convmnist():

--- a/tests/transformation/test_conv_lowering.py
+++ b/tests/transformation/test_conv_lowering.py
@@ -46,8 +46,8 @@ from qonnx.util.basic import gen_finn_dt_tensor, qonnx_make_model
 from qonnx.util.test import download_model, get_golden_in_and_output
 
 
-def test_conv_lowering_quant_weights():
-    model_name = "FINN-CNV_W2A2"
+@pytest.mark.parametrize("model_name", ["FINN-CNV_W2A2", "MobileNetv1-w4a4"])
+def test_conv_lowering_quant_weights(model_name):
     model = download_model(model_name, return_modelwrapper=True, do_cleanup=True)
     model = model.transform(LowerConvsToMatMul())
     assert model.get_nodes_by_op_type("Conv") == []

--- a/tests/transformation/test_conv_lowering.py
+++ b/tests/transformation/test_conv_lowering.py
@@ -43,7 +43,7 @@ from qonnx.custom_op.registry import getCustomOp
 from qonnx.transformation.infer_shapes import InferShapes
 from qonnx.transformation.lower_convs_to_matmul import LowerConvsToMatMul
 from qonnx.util.basic import gen_finn_dt_tensor, qonnx_make_model
-from qonnx.util.test import download_model
+from qonnx.util.test import download_model, get_golden_in_and_output
 
 
 def test_conv_lowering_quant_weights():
@@ -51,6 +51,11 @@ def test_conv_lowering_quant_weights():
     model = download_model(model_name, return_modelwrapper=True, do_cleanup=True)
     model = model.transform(LowerConvsToMatMul())
     assert model.get_nodes_by_op_type("Conv") == []
+    input_t, golden_t = get_golden_in_and_output(model_name)
+    input_dict = {model.graph.input[0].name: input_t}
+    prod_dict = oxe.execute_onnx(model, input_dict)
+    prod_t = prod_dict[model.graph.output[0].name]
+    assert (prod_t == golden_t).all()
 
 
 def test_conv_lowering_convmnist():


### PR DESCRIPTION
The `LowerConvsToMatMul` transformation previously only worked with `Conv` nodes that have a static initializer as the weight input. This PR extends the capabilities to deal with the case where the weights are fed by a `Quant` node, including any transpose/reshape required for the scale factors. See example below (before/after, from a 4-bit MobileNet-v1)

![image](https://github.com/user-attachments/assets/c6c7f402-f167-4c37-ae9a-f547ad7ff96f)
![image](https://github.com/user-attachments/assets/889bec82-8310-4829-8004-7846e2260f2b)
