### PR TITLE
[MultiThreshold] Generalize data layouts for node execution

### DIFF
--- a/src/qonnx/custom_op/general/multithreshold.py
+++ b/src/qonnx/custom_op/general/multithreshold.py
@@ -100,7 +100,7 @@ class MultiThreshold(CustomOp):
             "out_dtype": ("s", True, ""),
             "out_scale": ("f", False, 1.0),
             "out_bias": ("f", False, 0.0),
-            "data_layout": ("s", False, "NCHW"),
+            "data_layout": ("s", False, ""),
         }
 
     def make_shape_compatible_op(self, model):
@@ -135,6 +135,13 @@ class MultiThreshold(CustomOp):
         # accepted by the multithreshold function above, i.e, the channel
         # dimension is along the axis with index 1.
         data_layout = self.get_nodeattr("data_layout")
+        # If there is no layout annotation, guess based on rank of the
+        # tensor
+        if not data_layout and len(v.shape) < 5:
+            # Maps tensor rank to layout annotation
+            rank_to_layout = {0: None, 1: "C", 2: "NC", 3: "NWC", 4: "NCHW"}
+            # Lookup the layout required by this input shape
+            data_layout = rank_to_layout[len(v.shape)]
         # Lookup the index of the channel dimension in the data layout
         # Note: Assumes there is at most one "C" which denotes the channel
         # dimension

--- a/src/qonnx/custom_op/general/multithreshold.py
+++ b/src/qonnx/custom_op/general/multithreshold.py
@@ -139,13 +139,16 @@ class MultiThreshold(CustomOp):
         # tensor
         if not data_layout and len(v.shape) < 5:
             # Maps tensor rank to layout annotation
-            rank_to_layout = {0: None, 1: "C", 2: "NC", 3: "NWC", 4: "NCHW"}
+            rank_to_layout = {0: None, 1: None, 2: "NC", 3: "NWC", 4: "NCHW"}
             # Lookup the layout required by this input shape
             data_layout = rank_to_layout[len(v.shape)]
         # Lookup the index of the channel dimension in the data layout
         # Note: Assumes there is at most one "C" which denotes the channel
         # dimension
-        cdim = data_layout.index("C") if "C" in data_layout else 1
+        if data_layout is not None:
+            cdim = data_layout.index("C") if "C" in data_layout else 1
+        else:
+            cdim = 1
         # Rearrange the input to the expected (N, C, ...) layout
         orig_shape = v.shape
         v = v.swapaxes(cdim, 1)


### PR DESCRIPTION
The relevant aspect of the data layout annotation seems to be which axis is labeled as the channel dimension "C": We do not actually have to care about the total number and ordering of the other axes, as long as we can find the index of the "C" axis and swap to have "C" at index 1 for node execution (and swap it back afterwards).

Falls back to the default assumption that "C" is at index 1 if there is no layout annotation, which is equivalent to the "NCHW" or "NC" layouts.

This is a rather experimental change which might break existing code and is currently still restricted to the well-known 2-, 3- and 4-dimensional layouts.

This PR is based on #92 which is less experimental and should be merged first (#92 also does not risk breaking existing code as it only adds new special cases).