### PR TITLE
Op Registry upgrade

### DIFF
--- a/src/qonnx/custom_op/registry.py
+++ b/src/qonnx/custom_op/registry.py
@@ -30,6 +30,20 @@ import importlib
 
 from qonnx.util.basic import get_preferred_onnx_opset
 
+_QONNX_DOMAINS = ["finn", "qonnx.custom_op", "onnx.brevitas"]
+
+
+def register_custom_domain(domain: str):
+    _QONNX_DOMAINS.append(domain)
+
+
+def is_finn_op(op_type):
+    "Return whether given op_type string is a QONNX or FINN custom op"
+    is_finn = False
+    for domain in _QONNX_DOMAINS:
+        is_finn = is_finn or op_type.startswith(domain)
+    return is_finn
+
 
 def getCustomOp(node, onnx_opset_version=get_preferred_onnx_opset(), brevitas_exception=True):
     "Return a QONNX CustomOp instance for the given ONNX node, if it exists."

--- a/src/qonnx/custom_op/registry.py
+++ b/src/qonnx/custom_op/registry.py
@@ -28,8 +28,6 @@
 
 import importlib
 
-from qonnx.util.basic import get_preferred_onnx_opset
-
 _QONNX_DOMAINS = ["finn", "qonnx.custom_op", "onnx.brevitas"]
 
 
@@ -43,6 +41,11 @@ def is_finn_op(op_type):
     for domain in _QONNX_DOMAINS:
         is_finn = is_finn or op_type.startswith(domain)
     return is_finn
+
+
+def get_preferred_onnx_opset():
+    "Return preferred ONNX opset version for QONNX"
+    return 11
 
 
 def getCustomOp(node, onnx_opset_version=get_preferred_onnx_opset(), brevitas_exception=True):

--- a/src/qonnx/util/basic.py
+++ b/src/qonnx/util/basic.py
@@ -32,6 +32,9 @@ import random
 import string
 import warnings
 
+import qonnx
+import qonnx.custom_op
+import qonnx.custom_op.registry
 from qonnx.core.datatype import DataType
 
 # TODO solve by moving onnx-dependent fxns to onnx.py
@@ -63,8 +66,7 @@ def qonnx_make_model(graph_proto, **kwargs):
 
 
 def is_finn_op(op_type):
-    "Return whether given op_type string is a QONNX or FINN custom op"
-    return op_type.startswith("finn") or op_type.startswith("qonnx.custom_op") or op_type.startswith("onnx.brevitas")
+    return qonnx.custom_op.registry.is_finn_op(op_type)
 
 
 def get_num_default_workers():

--- a/src/qonnx/util/basic.py
+++ b/src/qonnx/util/basic.py
@@ -51,7 +51,7 @@ except ModuleNotFoundError:
 
 def get_preferred_onnx_opset():
     "Return preferred ONNX opset version for QONNX"
-    return 11
+    return qonnx.custom_op.registry.get_preferred_onnx_opset()
 
 
 def qonnx_make_model(graph_proto, **kwargs):


### PR DESCRIPTION
This PR makes it possible to add QONNX Ops from outside the brevitas/finn/qonnx repositories. It adds a function `register_custom_domain` .

This is an example of usage of this functionality in chisel4ml:
    - https://github.com/cs-jsi/chisel4ml/blob/auto_parameters/chisel4ml/preprocess/fft_torch_op.py 
    - https://github.com/cs-jsi/chisel4ml/blob/auto_parameters/chisel4ml/preprocess/fft_qonnx_op.py

It defines a custom pytorch op, that then gets mapped to a (Q)ONNX op.

This PR should not affect other peoples code.