### PR TITLE
Add more activations that a transpose can move through

### DIFF
--- a/src/qonnx/transformation/channels_last.py
+++ b/src/qonnx/transformation/channels_last.py
@@ -44,7 +44,7 @@ _channelsLast_node_types = list(channels_last.custom_op.keys())
 
 # Nodes, which do not modify the shape of the tensor
 # And modify all values in the same way.
-_move_through_nodes = ["Quant", "Relu"]
+_move_through_nodes = ["Quant", "Relu", "Selu", "LeakyRelu", "Sigmoid", "Tanh"]
 
 # Nodes, which do not modify the shape of the tensor,
 # And modify all values in the same way, if the second tensor is a scalar.


### PR DESCRIPTION
The channels-last conversion transpose should be able to pass over activations that are applied element-wise. Therefore, I added more nodes that can be skipped.

There is a test in hls4ml that fails without this change since it uses a Selu activation. I am not sure if more tests are needed in the qonnx repository for this.