### PR TITLE
Added transformation to remove successive and identical `Quant` nodes in the graph

### DIFF
--- a/src/qonnx/transformation/remove.py
+++ b/src/qonnx/transformation/remove.py
@@ -158,3 +158,4 @@ class RemoveSuccessiveIdenticalQuant(Transformation):
                     if init_node == init_succ:
                         remove_node_and_rewire(model, n)
         return (model, graph_modified)
+    


### PR DESCRIPTION
Since I used this transformation for Edge SpAIce project, I thought this might be generally useful. Sometimes it happens that the model exported from Brevitas contains repeated `Quant` nodes. Using this transformation, only one of the two remains in the graph, potentially simplifying to process the graph by other tools used after QONNX, such as hls4ml. I am also not sure if we should add this in the `cleanup()` or leave it as optional.