### PR TITLE
Fix incorrect value_info setting in MergeONNXModels

### DIFF
--- a/src/qonnx/transformation/merge_onnx_models.py
+++ b/src/qonnx/transformation/merge_onnx_models.py
@@ -130,15 +130,15 @@ class MergeONNXModels(Transformation):
         outp = post_model.graph.output[0]
 
         vi_pre = [x for x in pre_model.graph.value_info]
-        out_pre = [x for x in pre_model.graph.output]
         qa_pre = [x for x in pre_model.graph.quantization_annotation]
         init_pre = [x for x in pre_model.graph.initializer]
 
         vi_post = [x for x in post_model.graph.value_info]
+        in_post = [x for x in post_model.graph.input]
         qa_post = [x for x in post_model.graph.quantization_annotation]
         init_post = [x for x in post_model.graph.initializer]
 
-        vi_new = vi_pre + vi_post + out_pre
+        vi_new = vi_pre + vi_post + in_post
         qa_new = qa_pre + qa_post
         init_new = init_pre + init_post
 


### PR DESCRIPTION
We connect the output of the pre_model to the input tensor of the post_model. 

**Old behavior: The output tensor of pre_model is added to the value_info of the output model**, even though this tensor is no longer used. The input tensor of post_model is missing a value_info entry. This causes errors in FINN shape inference because no shape can be annotated to this tensor, but CustomOps expect their input tensor shape to be annotated.

**New behavior: The input tensor of post_model is added to the value_info of the output model.**
