### PR TITLE
Remove identity nodes with output forking

### DIFF
--- a/src/qonnx/transformation/remove.py
+++ b/src/qonnx/transformation/remove.py
@@ -113,20 +113,20 @@ class RemoveIdentityOps(Transformation):
         graph_modified = False
         for node in graph.node:
             node_ind += 1
-            if node.op_type in ["Add", "Sub"] and not model.is_fork_node(node) and not model.is_join_node(node):
+            if node.op_type in ["Add", "Sub"]:
                 A = model.get_initializer(node.input[1])
                 if A is not None and np.isclose(A, np.zeros_like(A), atol=self.atol).all():
                     remove_node_and_rewire(model, node)
                     graph_modified = True
                     break
 
-            elif node.op_type in ["Mul", "Div"] and not model.is_fork_node(node) and not model.is_join_node(node):
+            elif node.op_type in ["Mul", "Div"]:
                 A = model.get_initializer(node.input[1])
                 if A is not None and np.isclose(A, np.ones_like(A), atol=self.atol).all():
                     remove_node_and_rewire(model, node)
                     graph_modified = True
                     break
-            elif node.op_type == "Pad" and not model.is_fork_node(node) and not model.is_join_node(node):
+            elif node.op_type == "Pad":
                 pads = get_by_name(node.attribute, "pads")
                 if pads is not None:
                     # older versions of Pad op specify pads as attribute


### PR DESCRIPTION
Previously, `RemoveIdentityOps` did not touch identity ops with forking outputs by excluding such nodes with a conditional. This PR removes that, and adds output forking to the corresponding test to ensure that identity nodes with forking outputs are removed correctly. These tests (in combination with all existing cases in the remove identity test) pass successfully. Example output-forked identity graph follows.

Before:
![image](https://github.com/user-attachments/assets/0147b797-9d60-42d7-b06f-3cb6b78c2bb6)

After:
![image](https://github.com/user-attachments/assets/91f099e7-b5f9-42ea-b28b-73d2f490ba1d)
