### PR TITLE
update tensorflow and qonnx requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -70,8 +70,8 @@ exclude =
 qkeras =
     pyparsing
     tf2onnx>=1.16.1
-    tensorflow==2.9.0
-    QKeras==0.9.0
+    tensorflow>=2.9.0, <=2.14.1
+    QKeras>=0.9.0
 
 # Add here test requirements (semicolon/line-separated)
 testing =


### PR DESCRIPTION
This PR updates the tensorflow and QKeras requirements. The keras pytests succeeded in my python 3.11-based test setup. 