### PR TITLE
Delete tensor initializer

### DIFF
--- a/src/qonnx/core/modelwrapper.py
+++ b/src/qonnx/core/modelwrapper.py
@@ -370,10 +370,9 @@ class ModelWrapper:
     def del_initializer(self, initializer_name):
         """Deletes an initializer from the model."""
         graph = self._model_proto.graph
-        for init in graph.initializer:
-            if init.name == initializer_name:
-                graph.initializer.remove(init)
-                break
+        init = util.get_by_name(graph.initializer, initializer_name)
+        if not (init is None):
+            graph.initializer.remove(init)
 
     def find_producer(self, tensor_name):
         """Finds and returns the node that produces the tensor with given name."""

--- a/src/qonnx/core/modelwrapper.py
+++ b/src/qonnx/core/modelwrapper.py
@@ -367,6 +367,14 @@ class ModelWrapper:
             else:
                 return None
 
+    def del_initializer(self, initializer_name):
+        """Deletes an initializer from the model."""
+        graph = self._model_proto.graph
+        for init in graph.initializer:
+            if init.name == initializer_name:
+                graph.initializer.remove(init)
+                break
+
     def find_producer(self, tensor_name):
         """Finds and returns the node that produces the tensor with given name."""
         for x in self._model_proto.graph.node:

--- a/tests/core/test_modelwrapper.py
+++ b/tests/core/test_modelwrapper.py
@@ -54,11 +54,6 @@ def test_modelwrapper():
     assert first_conv_iname != "" and (first_conv_iname is not None)
     assert first_conv_wname != "" and (first_conv_wname is not None)
     assert first_conv_oname != "" and (first_conv_oname is not None)
-    first_conv_weights = model.get_initializer(first_conv_wname)
-    assert first_conv_weights.shape == (8, 1, 5, 5)
-    first_conv_weights_rand = np.random.randn(8, 1, 5, 5)
-    model.set_initializer(first_conv_wname, first_conv_weights_rand)
-    assert (model.get_initializer(first_conv_wname) == first_conv_weights_rand).all()
     inp_cons = model.find_consumer(first_conv_iname)
     assert inp_cons == first_conv
     out_prod = model.find_producer(first_conv_oname)
@@ -73,6 +68,21 @@ def test_modelwrapper():
     inp_sparsity = {"dw": {"kernel_shape": [3, 3]}}
     model.set_tensor_sparsity(first_conv_iname, inp_sparsity)
     assert model.get_tensor_sparsity(first_conv_iname) == inp_sparsity
+
+
+def test_modelwrapper_set_get_rm_initializer():
+    raw_m = get_data("qonnx.data", "onnx/mnist-conv/model.onnx")
+    model = ModelWrapper(raw_m)
+    conv_nodes = model.get_nodes_by_op_type("Conv")
+    first_conv = conv_nodes[0]
+    first_conv_wname = first_conv.input[1]
+    first_conv_weights = model.get_initializer(first_conv_wname)
+    assert first_conv_weights.shape == (8, 1, 5, 5)
+    first_conv_weights_rand = np.random.randn(8, 1, 5, 5)
+    model.set_initializer(first_conv_wname, first_conv_weights_rand)
+    assert (model.get_initializer(first_conv_wname) == first_conv_weights_rand).all()
+    model.del_initializer(first_conv_wname)
+    assert model.get_initializer(first_conv_wname) is None
 
 
 def test_modelwrapper_graph_order():


### PR DESCRIPTION
See original PR #139 . Cherry-picked key commit, added test and re-factored to use `util.get_by_name`.