### PR TITLE
Add GiveUniqueParameterTensors to ModelWrapper.cleanup transformations

### DIFF
--- a/src/qonnx/core/modelwrapper.py
+++ b/src/qonnx/core/modelwrapper.py
@@ -41,6 +41,7 @@ from qonnx.transformation.double_to_single_float import DoubleToSingleFloat
 from qonnx.transformation.general import (
     RemoveStaticGraphInputs,
     RemoveUnusedTensors,
+    GiveUniqueParameterTensors,
     SortCommutativeInputsInitializerLast,
     SortGraph,
 )
@@ -155,6 +156,7 @@ class ModelWrapper:
             RemoveStaticGraphInputs(),
             SortGraph(),
             SortCommutativeInputsInitializerLast(),
+            GiveUniqueParameterTensors(),
         ]
         for trn in cleanup_transforms:
             transformed_model = transformed_model.transform(trn, cleanup=False, make_deepcopy=False)


### PR DESCRIPTION
Fixes transformations which create copies of nodes without copying parameter tensors, resulting in unwanted entanglement. This manifests as later transformations having non-local effects, manipulating seemingly unrelated nodes.