### PR TITLE
[trunc/quant_avg_pool] Update Trunc and QuantAveragePool to match how Brevitas Ops work

### DIFF
--- a/docs/qonnx-custom-ops/trunc_op.md
+++ b/docs/qonnx-custom-ops/trunc_op.md
@@ -18,8 +18,6 @@ The description of this operator in this document corresponds to `qonnx.custom_o
 <dd>Defines if the quantization includes a signed bit. E.g. at 8b unsigned=[0, 255] vs signed=[-128, 127].</dd>
 <dt><tt>narrow</tt> : int (default is 0)</dt>
 <dd>Defines if the value range should be interpreted as narrow, when signed=1. E.g. at 8b regular=[-128, 127] vs narrow=[-127, 127].</dd>
-<dt><tt>output_scale</tt> : float32 (default is -1.0)</dt>
-<dd>The scale factor of the output as a scalar. The output scale must represent a shift W.R.T. the input scale (i.e., scale) and therefore must be the input scale multiplied by a power-of-2. If output_scale is less-than-or-equal to 0, it is calculated as 2 ** (in_bitwidth - out_bitwidth) to approximately match the behaviour of qonnx.custom_ops.general opset version 1.</dd>
 </dl>
 
 #### Inputs
@@ -28,11 +26,13 @@ The description of this operator in this document corresponds to `qonnx.custom_o
 <dt><tt>X</tt> (differentiable) : tensor(float32)</dt>
 <dd>input tensor to truncate</dd>
 <dt><tt>scale</tt> : float32</dt>
-<dd>The scale factor</dd>
+<dd>The scale factor at the input of the truncation</dd>
 <dt><tt>zeropt</tt> : float32</dt>
-<dd>The zero-point</dd>
+<dd>The zero-point at the input of the truncation</dd>
 <dt><tt>in_bitwidth</tt> : int32</dt>
 <dd>The number of bits used at the input of the truncation</dd>
+<dt><tt>out_scale</tt> : float32</dt>
+<dd>The scale factor of the output of the truncation</dd>
 <dt><tt>out_bitwidth</tt> : int32</dt>
 <dd>The number of bits used at the output of the truncation</dd>
 </dl>

--- a/docs/qonnx-custom-ops/trunc_op.md
+++ b/docs/qonnx-custom-ops/trunc_op.md
@@ -18,8 +18,8 @@ The description of this operator in this document corresponds to `qonnx.custom_o
 <dd>Defines if the quantization includes a signed bit. E.g. at 8b unsigned=[0, 255] vs signed=[-128, 127].</dd>
 <dt><tt>narrow</tt> : int (default is 0)</dt>
 <dd>Defines if the value range should be interpreted as narrow, when signed=1. E.g. at 8b regular=[-128, 127] vs narrow=[-127, 127].</dd>
-<dt><tt>output_scale</tt> : float32, tensor(float32) (default is -1.0)</dt>
-<dd>The scale factor of the output, either as a global scalar or with a shape matching the number of dimensions of the X tensor. The output scale must represent a shift W.R.T. the input scale (i.e., <tt>scale</tt>) and therefore must be the input scale multiplied by a power-of-2. If output_scale is less-than-or-equal to 0, it is calculated as 2 ** (in_bitwidth - out_bitwidth) to approximately match the behaviour in qonnx.custom_ops.general opset version 1.</dd>
+<dt><tt>output_scale</tt> : float32 (default is -1.0)</dt>
+<dd>The scale factor of the output as a scalar. The output scale must represent a shift W.R.T. the input scale (i.e., scale) and therefore must be the input scale multiplied by a power-of-2. If output_scale is less-than-or-equal to 0, it is calculated as 2 ** (in_bitwidth - out_bitwidth) to approximately match the behaviour of qonnx.custom_ops.general opset version 1.</dd>
 </dl>
 
 #### Inputs

--- a/src/qonnx/custom_op/general/trunc.py
+++ b/src/qonnx/custom_op/general/trunc.py
@@ -100,8 +100,7 @@ class Trunc(CustomOp):
         zeropt = context[node.input[2]]
         input_bit_width = context[node.input[3]]
         output_scale = context[node.input[4]]
-        output_zeropt = context[node.input[5]]
-        output_bit_width = context[node.input[6]]
+        output_bit_width = context[node.input[5]]
         # save attributes
         rounding_mode = self.get_nodeattr("rounding_mode")
         narrow = self.get_nodeattr("narrow")

--- a/src/qonnx/custom_op/general/trunc.py
+++ b/src/qonnx/custom_op/general/trunc.py
@@ -66,10 +66,10 @@ def trunc(inp_tensor, scale, zeropt, input_bit_width, narrow, signed, output_sca
 
 
 class Trunc(CustomOp):
-    """Generic truncation operation for QONNX. Takes four inputs:
-    - input tensor to truncate
-    - the scale
-    - the zero-point
+    """Generic truncation operation for QONNX. Takes four inputs:  
+    - input tensor to truncate  
+    - the scale  
+    - the zero-point  
     - the truncation bit-width
 
     The output is a tensor of the same shape as the input tensor, with truncated

--- a/src/qonnx/custom_op/general/trunc.py
+++ b/src/qonnx/custom_op/general/trunc.py
@@ -70,6 +70,7 @@ class Trunc(CustomOp):
     - input tensor to truncate  
     - the scale  
     - the zero-point  
+    - the truncation scale  
     - the truncation bit-width
 
     The output is a tensor of the same shape as the input tensor, with truncated

--- a/src/qonnx/custom_op/general/trunc.py
+++ b/src/qonnx/custom_op/general/trunc.py
@@ -82,11 +82,6 @@ class Trunc(CustomOp):
             "rounding_mode": ("s", True, "FLOOR"),
             "narrow": ("i", False, 0, {0, 1}),
             "signed": ("i", False, 1, {0, 1}),
-            "output_scale": (
-                "f",
-                False,
-                -1.0,
-            ),  # Invalid scale signifies that it needs to be computed from input/output bit_width
         }
 
     def make_shape_compatible_op(self, model):
@@ -104,13 +99,13 @@ class Trunc(CustomOp):
         scale = context[node.input[1]]
         zeropt = context[node.input[2]]
         input_bit_width = context[node.input[3]]
-        output_bit_width = context[node.input[4]]
+        output_scale = context[node.input[4]]
+        output_zeropt = context[node.input[5]]
+        output_bit_width = context[node.input[6]]
         # save attributes
         rounding_mode = self.get_nodeattr("rounding_mode")
         narrow = self.get_nodeattr("narrow")
         signed = self.get_nodeattr("signed")
-        output_scale = self.get_nodeattr("output_scale")
-        output_scale = 2 ** (input_bit_width - output_bit_width) if output_scale <= 0.0 else output_scale
         # calculate output
         ret = trunc(
             inp_tensor, scale, zeropt, input_bit_width, narrow, signed, output_scale, output_bit_width, rounding_mode


### PR DESCRIPTION
Brevitas used to have some weird behaviour W.R.T. how average pool and trunc used to work (both separately and together). The original behaviour and a new proposal is detailed [here](https://github.com/Xilinx/brevitas/pull/1042). The purpose of this PR is to make changes on the QONNX side which match the new proposal.

TODO:
 - [x] Update `Trunc` behaviour to match the new behaviour in Brevitas
 - [x] Update the [`trunc_op`](https://github.com/fastmachinelearning/qonnx/blob/main/docs/qonnx-custom-ops/trunc_op.md) spec to match the new functionality
 - [ ] ~Update `QuantAveragePool2D` to match the new behaviour in Brevitas~ - TODO in a separate PR