### PR TITLE
[Opset] Increase preferred opset version to 13

### DIFF
--- a/src/qonnx/util/basic.py
+++ b/src/qonnx/util/basic.py
@@ -48,7 +48,7 @@ except ModuleNotFoundError:
 
 def get_preferred_onnx_opset():
     "Return preferred ONNX opset version for QONNX"
-    return 11
+    return 12
 
 
 def qonnx_make_model(graph_proto, **kwargs):

--- a/src/qonnx/util/basic.py
+++ b/src/qonnx/util/basic.py
@@ -48,7 +48,7 @@ except ModuleNotFoundError:
 
 def get_preferred_onnx_opset():
     "Return preferred ONNX opset version for QONNX"
-    return 12
+    return 13
 
 
 def qonnx_make_model(graph_proto, **kwargs):


### PR DESCRIPTION
This opset version is required by Split and Concat as implemented in FINN by Xilinx/finn PRs [#1189](https://github.com/Xilinx/finn/pull/1189), [#1193](https://github.com/Xilinx/finn/pull/1193) and [#1194](https://github.com/Xilinx/finn/pull/1194).