### PR TITLE
Disable coverage in pytest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -120,7 +120,6 @@ pytest_randomly.random_seeder =
 # CAUTION: --cov flags may prohibit setting breakpoints while debugging.
 #          Comment those flags to avoid this py.test issue.
 addopts =
-    --cov qonnx --cov-report term-missing
     --verbose
 norecursedirs =
     dist


### PR DESCRIPTION
The coverage report (which is enabled by default when invoking `pytest`) takes up quite a bit of space in the terminal, and at the moment we don't make use of it. Opting to disable it for now.