### PR TITLE
Fix ModelWrapper method to preserve order of graph inputs and outputs

### DIFF
--- a/src/qonnx/core/modelwrapper.py
+++ b/src/qonnx/core/modelwrapper.py
@@ -291,7 +291,7 @@ class ModelWrapper:
             else:
                 dtype = old_vi.type.tensor_type.elem_type
         new_vi = oh.make_tensor_value_info(tensor_name, dtype, tensor_shape)
-        # find what container tHis tensor's ValueInfo lives in
+        # find what container this tensor's ValueInfo lives in
         # if not found anywhere, we assume it's a new value_info
         target_container = self.graph.value_info
         if util.get_by_name(self.graph.input, tensor_name) is not None:
@@ -308,7 +308,10 @@ class ModelWrapper:
             ind = outputs.index(tensor_name)
         # remove from target container and add new
         util.remove_by_name(target_container, tensor_name)
-        target_container.insert(ind, new_vi)
+        if target_container == self.graph.value_info:
+            target_container.append(new_vi)
+        else:
+            target_container.insert(ind, new_vi)
 
     def set_initializer(self, tensor_name, tensor_value):
         """Sets the initializer value for tensor with given name."""

--- a/src/qonnx/core/modelwrapper.py
+++ b/src/qonnx/core/modelwrapper.py
@@ -296,11 +296,19 @@ class ModelWrapper:
         target_container = self.graph.value_info
         if util.get_by_name(self.graph.input, tensor_name) is not None:
             target_container = self.graph.input
+            # create list from inputs to find index
+            inputs = [x.name for x in self.graph.input]
+            # save index of input to preserve order
+            ind = inputs.index(tensor_name)
         if util.get_by_name(self.graph.output, tensor_name) is not None:
             target_container = self.graph.output
+            # create list from inputs to find index
+            outputs = [x.name for x in self.graph.output]
+            # save index of input to preserve order
+            ind = outputs.index(tensor_name)
         # remove from target container and add new
         util.remove_by_name(target_container, tensor_name)
-        target_container.append(new_vi)
+        target_container.insert(ind, new_vi)
 
     def set_initializer(self, tensor_name, tensor_value):
         """Sets the initializer value for tensor with given name."""


### PR DESCRIPTION
This PR fixes an issue with `set_tensor_shape` and the order of input and output tensors in the ONNX GraphProto. When setting the shape of these tensors, they used to be removed and then re-added, which potentially could mess up their order. This wasn't a problem for internal tensors (ValueInfo is unordered), but can lead to a reordering of graph.input or graph.output.

In this PR, the code now fetches the current index of the tensor in graph.input or graph.output. It then inserts the updated tensor with its new shape back into the same spot, keeping the original order intact.