### PR TITLE
Store Metadata in Graph Proto rather than model Proto

### DIFF
--- a/src/qonnx/core/modelwrapper.py
+++ b/src/qonnx/core/modelwrapper.py
@@ -566,7 +566,7 @@ class ModelWrapper:
     def get_metadata_prop(self, key):
         """Returns the value associated with metadata_prop with given key,
         or None otherwise."""
-        metadata_prop = util.get_by_name(self.model.metadata_props, key, "key")
+        metadata_prop = util.get_by_name(self.model.graph.metadata_props, key, "key")
         if metadata_prop is None:
             return None
         else:
@@ -574,12 +574,12 @@ class ModelWrapper:
 
     def set_metadata_prop(self, key, value):
         """Sets metadata property with given key to the given value."""
-        metadata_prop = util.get_by_name(self.model.metadata_props, key, "key")
+        metadata_prop = util.get_by_name(self.model.graph.metadata_props, key, "key")
         if metadata_prop is None:
             metadata_prop = onnx.StringStringEntryProto()
             metadata_prop.key = key
             metadata_prop.value = value
-            self.model.metadata_props.append(metadata_prop)
+            self.model.graph.metadata_props.append(metadata_prop)
         else:
             metadata_prop.value = value
 


### PR DESCRIPTION
Moving the modelwrapper set_metadata_props and get_metadata_props to refer to the graph proto rather than the model proto. This is primary being done to enable future support for subgraph transforms in QONNX. This way when a transform is applied to a subgraph the subgraph retains the metadata and metadata does not have to be copied between parent and child graphs.  