### PR TITLE
Fix SortGraph Removes Nodes Connected only to I/O

### DIFF
--- a/src/qonnx/transformation/general.py
+++ b/src/qonnx/transformation/general.py
@@ -248,7 +248,8 @@ class SortGraph(Transformation):
                     # check if node inputs are connected to graph inputs or initializers
                     # if so, we can keep the node in the graph
                     for name in n.input:
-                        if model.get_initializer(name) or util.get_by_name(model.graph.input, name, "name"):
+                        if util.get_by_name(model.graph.initializer, name) or \
+                           util.get_by_name(model.graph.input, name):
                             # this node is connected to graph inputs or initializers
                             # so we can keep it in the graph
                             graph_dependencies[node_idx] = set()

--- a/src/qonnx/transformation/general.py
+++ b/src/qonnx/transformation/general.py
@@ -244,6 +244,15 @@ class SortGraph(Transformation):
         for node_idx, n in enumerate(node_list):
             node_pred = model.find_direct_predecessors(n)
             if node_pred is None:
+                if len(n.input) > 0:
+                    # check if node inputs are connected to graph inputs or initializers
+                    # if so, we can keep the node in the graph
+                    for name in n.input:
+                        if model.get_initializer(name) or util.get_by_name(model.graph.input, name, "name"):
+                            # this node is connected to graph inputs or initializers
+                            # so we can keep it in the graph
+                            graph_dependencies[node_idx] = set()
+                            break
                 # Will also eliminate nodes that are floating around for some reason
                 continue
 
@@ -262,6 +271,7 @@ class SortGraph(Transformation):
             model.graph.node.insert(new_idx, node_list[sorted_idx])
 
         return (model, False)
+
 
 
 class ConvertSubToAdd(Transformation):


### PR DESCRIPTION
The PR fixes a bug in the SortGraph transformation that removes nodes (that should be kept) that were only connected to graph inputs and outputs. The fix inserts code that checks for the node inputs for a connection to a graph input or initializer. If one is found than it inserts an empty dependency to prevent the node from being removed from the graph.   