### PR TITLE
[DataType] vectorize checking if value is allowed for a datatype

### DIFF
--- a/tests/core/test_datatypes.py
+++ b/tests/core/test_datatypes.py
@@ -26,6 +26,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import pytest
 import numpy as np
 
 from qonnx.core.datatype import DataType, resolve_datatype
@@ -33,39 +34,39 @@ from qonnx.core.datatype import DataType, resolve_datatype
 
 def test_datatypes():
     assert DataType["BIPOLAR"].allowed(-1)
-    assert DataType["BIPOLAR"].allowed(0) is False
-    assert DataType["BINARY"].allowed(-1) is False
+    assert bool(DataType["BIPOLAR"].allowed(0)) is False
+    assert bool(DataType["BINARY"].allowed(-1)) is False
     assert DataType["BINARY"].allowed(1)
-    assert DataType["TERNARY"].allowed(2) is False
+    assert bool(DataType["TERNARY"].allowed(2)) is False
     assert DataType["TERNARY"].allowed(-1)
     assert DataType["UINT2"].allowed(2)
-    assert DataType["UINT2"].allowed(10) is False
+    assert bool(DataType["UINT2"].allowed(10)) is False
     assert DataType["UINT3"].allowed(5)
-    assert DataType["UINT3"].allowed(-7) is False
+    assert bool(DataType["UINT3"].allowed(-7)) is False
     assert DataType["UINT4"].allowed(15)
-    assert DataType["UINT4"].allowed(150) is False
+    assert bool(DataType["UINT4"].allowed(150)) is False
     assert DataType["UINT8"].allowed(150)
-    assert DataType["UINT8"].allowed(777) is False
+    assert bool(DataType["UINT8"].allowed(777)) is False
     assert DataType["UINT8"].to_numpy_dt() == np.uint8
     assert DataType["UINT16"].allowed(14500)
     assert DataType["UINT16"].to_numpy_dt() == np.uint16
-    assert DataType["UINT16"].allowed(-1) is False
+    assert bool(DataType["UINT16"].allowed(-1)) is False
     assert DataType["UINT32"].allowed(2**10)
-    assert DataType["UINT32"].allowed(-1) is False
+    assert bool(DataType["UINT32"].allowed(-1)) is False
     assert DataType["UINT32"].to_numpy_dt() == np.uint32
     assert DataType["INT2"].allowed(-1)
-    assert DataType["INT2"].allowed(-10) is False
-    assert DataType["INT3"].allowed(5) is False
+    assert bool(DataType["INT2"].allowed(-10)) is False
+    assert bool(DataType["INT3"].allowed(5)) is False
     assert DataType["INT3"].allowed(-2)
-    assert DataType["INT4"].allowed(15) is False
+    assert bool(DataType["INT4"].allowed(15)) is False
     assert DataType["INT4"].allowed(-5)
-    assert DataType["INT8"].allowed(150) is False
+    assert bool(DataType["INT8"].allowed(150)) is False
     assert DataType["INT8"].allowed(-127)
     assert DataType["INT8"].to_numpy_dt() == np.int8
-    assert DataType["INT16"].allowed(-1.04) is False
+    assert bool(DataType["INT16"].allowed(-1.04)) is False
     assert DataType["INT16"].allowed(-7777)
     assert DataType["INT16"].to_numpy_dt() == np.int16
-    assert DataType["INT32"].allowed(7.77) is False
+    assert bool(DataType["INT32"].allowed(7.77)) is False
     assert DataType["INT32"].allowed(-5)
     assert DataType["INT32"].allowed(5)
     assert DataType["INT32"].to_numpy_dt() == np.int32
@@ -85,7 +86,7 @@ def test_datatypes_fixedpoint():
     assert DataType["FIXED<4,2>"].max() == 1.75
     assert DataType["FIXED<4,2>"].allowed(1.5)
     assert DataType["FIXED<4,2>"].allowed(-1.5)
-    assert DataType["FIXED<4,2>"].allowed(1.8) is False
+    assert bool(DataType["FIXED<4,2>"].allowed(1.8)) is False
     assert DataType["FIXED<4,2>"].is_integer() is False
     assert DataType["FIXED<4,2>"].is_fixed_point() is True
     assert str(DataType["FIXED<4,2"]) == "FIXED<4,2>"
@@ -97,8 +98,8 @@ def test_datatypes_arbprecfloat():
     assert DataType["FLOAT<4,3>"].allowed(0.5)
     assert DataType["FLOAT<4,3>"].allowed(1.875)
     assert DataType["FLOAT<4,3>"].allowed(-1.5)
-    assert DataType["FLOAT<4,3>"].allowed(1.8) is False
-    assert DataType["FLOAT<4,3>"].allowed(-(2.0 * 2**8)) is False
+    assert bool(DataType["FLOAT<4,3>"].allowed(1.8)) is False
+    assert bool(DataType["FLOAT<4,3>"].allowed(-(2.0 * 2**8))) is False
     assert DataType["FLOAT<4,3>"].min() == -1.875 * 2**8
     assert DataType["FLOAT<4,3>"].max() == 1.875 * 2**8
     assert DataType["FLOAT<4,3>"].to_numpy_dt() == np.float32
@@ -107,27 +108,27 @@ def test_datatypes_arbprecfloat():
     assert DataType["FLOAT<4,3>"].is_fixed_point() is False
     assert str(DataType["FLOAT<4,3>"]) == "FLOAT<4,3,7>"
     # test denormals
-    assert DataType["FLOAT<4,3>"].allowed(0.013671875) is True  # b1.110 * 2**-7
-    assert DataType["FLOAT<4,3>"].allowed(0.0087890625) is False  # b1.001 * 2**-7
-    assert DataType["FLOAT<4,3>"].allowed(0.001953125) is True  # b1.000 * 2**-9
-    assert DataType["FLOAT<4,3>"].allowed(0.0009765625) is False  # b1.000 * 2**-10
-    assert DataType["FLOAT<4,0>"].allowed(0.5) is True  # b1.000 * 2**-1
-    assert DataType["FLOAT<4,0>"].allowed(0.75) is False  # b1.100 * 2**-1
-    assert DataType["FLOAT<4,0>"].allowed(0.015625) is True  # b1.000 * 2**-6
-    assert DataType["FLOAT<4,0>"].allowed(0.0078125) is False  # b1.000 * 2**-7
+    assert bool(DataType["FLOAT<4,3>"].allowed(0.013671875)) is True  # b1.110 * 2**-7
+    assert bool(DataType["FLOAT<4,3>"].allowed(0.0087890625)) is False  # b1.001 * 2**-7
+    assert bool(DataType["FLOAT<4,3>"].allowed(0.001953125)) is True  # b1.000 * 2**-9
+    assert bool(DataType["FLOAT<4,3>"].allowed(0.0009765625)) is False  # b1.000 * 2**-10
+    assert bool(DataType["FLOAT<4,0>"].allowed(0.5)) is True  # b1.000 * 2**-1
+    assert bool(DataType["FLOAT<4,0>"].allowed(0.75)) is False  # b1.100 * 2**-1
+    assert bool(DataType["FLOAT<4,0>"].allowed(0.015625)) is True  # b1.000 * 2**-6
+    assert bool(DataType["FLOAT<4,0>"].allowed(0.0078125)) is False  # b1.000 * 2**-7
     # test custom exponent bias
     assert DataType["FLOAT<4,3,5>"].allowed(0.0)
     assert DataType["FLOAT<4,0,5>"].allowed(0.0)
     assert DataType["FLOAT<4,3,5>"].allowed(0.5)
     assert DataType["FLOAT<4,3,5>"].allowed(1.875)
     assert DataType["FLOAT<4,3,5>"].allowed(-1.5)
-    assert DataType["FLOAT<4,3,5>"].allowed(1.8) is False
-    assert DataType["FLOAT<4,3,5>"].allowed(-(2.0 * 2**8)) is True
+    assert bool(DataType["FLOAT<4,3,5>"].allowed(1.8)) is False
+    assert bool(DataType["FLOAT<4,3,5>"].allowed(-(2.0 * 2**8))) is True
     assert DataType["FLOAT<4,3,5>"].min() == -1.875 * 2**10
     assert DataType["FLOAT<4,3,5>"].max() == 1.875 * 2**10
     assert str(DataType["FLOAT<4,3,5>"]) == "FLOAT<4,3,5>"
-    assert DataType["FLOAT<4,0,5>"].allowed(0.0625) is True  # b1.000 * 2**-4
-    assert DataType["FLOAT<4,0,5>"].allowed(0.03125) is False  # b1.000 * 2**-5
+    assert bool(DataType["FLOAT<4,0,5>"].allowed(0.0625)) is True  # b1.000 * 2**-4
+    assert bool(DataType["FLOAT<4,0,5>"].allowed(0.03125)) is False  # b1.000 * 2**-5
 
 
 def test_smallest_possible():
@@ -185,3 +186,252 @@ def test_input_type_error():
     test_resolve_datatype(DataType["INT16"])
     test_resolve_datatype(DataType["INT32"])
     test_resolve_datatype(DataType["FLOAT32"])
+
+vectorize_details = {
+    "BIPOLAR": [
+        np.array([
+            [-1, +1,  0],
+            [ 0, +1, -1],
+            [+1,  0, -1]
+        ]),
+        np.array([
+            [True, True, False],
+            [False, True, True],
+            [True, False, True]
+        ], dtype=bool)
+    ],
+    "BINARY": [
+        np.array([
+            [-1, +1,  0],
+            [ 0, +1, -1],
+            [+1,  0, -1]
+        ]),
+        np.array([
+            [False, True, True],
+            [True, True, False],
+            [True, True, False]
+        ], dtype=bool)
+    ],
+    "TERNARY": [
+        np.array([
+            [-1, +2, +1,  0],
+            [ 0, +1, +2, -1],
+            [+2, +1,  0, -1]
+        ]),
+        np.array([
+            [True, False, True, True],
+            [True, True, False, True],
+            [False, True, True, True]
+        ], dtype=bool)
+    ],
+    "UINT2": [
+        np.array([
+            [[-1, +2, +1,  0],
+            [ 0, +1, +2, -1]],
+            [[+2, +1,  0, -1],
+            [+4, -1, -2, +3]],
+        ]),
+        np.array([
+            [[False, True, True, True],
+            [True, True, True, False]],
+            [[True, True, True, False],
+            [False, False, False, True]],
+        ], dtype=bool)
+    ],
+    "UINT3": [
+        np.array([
+            [[+9, -6, +3,  0],
+            [-4, +4,  0, +1]],
+            [[-1, +3, +10, +4],
+            [+2, +6, +7, +8]],
+        ]),
+        np.array([
+            [[False, False, True, True],
+            [False, True, True, True]],
+            [[False, True, False, True],
+            [True, True, True, False]],
+        ], dtype=bool)
+    ],
+    "UINT4": [
+        np.array([
+            [[-10, -4, +9, +13],
+            [+1, +14,  +11, +4]],
+            [[+18, -7, +1, +9],
+            [-1, -7, +1, -2]],
+        ]),
+        np.array([
+            [[False, False, True, True],
+            [True, True, True, True]],
+            [[False, False, True, True],
+            [False, False, True, False]],
+        ], dtype=bool)
+    ],
+    "UINT8": [
+        np.array([
+            [[148,  61,  70,  29],
+            [244, 213,  10, 135]],
+            [[18,  25, 246, 137],
+            [236, -31, 220, 359]],
+        ]),
+        np.array([
+            [[True, True, True, True],
+            [True, True, True, True]],
+            [[True, True, True, True],
+            [True, False, True, False]],
+        ], dtype=bool)
+    ],
+    "UINT16": [
+        np.array([
+            [[35261, 129491,   9136,  18643],
+            [128532,   -597,  34768,    248]],
+            [[21646,  30778,  71076,  21224],
+            [60657,  52854,  -5994,  17295]],
+        ]),
+        np.array([
+            [[True, False, True, True],
+            [False, False, True, True]],
+            [[True, True, False, True],
+            [True, True, False, True]],
+        ], dtype=bool)
+    ],
+    "UINT32": [
+        np.array([
+            [[-417565331,  3488834022, -1757218812,   591311876],
+            [1842515574,  4131239283,  2022242400,  1240578991]],
+            [[609779043,   574774725,  4188472937,  3109757181],
+            [-767760560, -2100731532,  3794040092,  3223013612]],
+        ]),
+        np.array([
+            [[False, True, False, True],
+            [True, True, True, True]],
+            [[True, True, True, True],
+            [False, False, True, True]],
+        ], dtype=bool)
+    ],
+    "INT2": [
+        np.array([
+            [[ 0,  2,  2,  3],
+            [-4,  2, -1,  2]],
+            [[ 1,  2, -4, -1],
+            [ 2, -1, -1, -2]],
+        ]),
+        np.array([
+            [[True, False, False, False],
+            [False, False, True, False]],
+            [[True, False, False, True],
+            [False, True, True, True]],
+        ], dtype=bool)
+    ],
+    "INT3": [
+        np.array([
+            [[-4, -6, -7,  3],
+            [ 2, -8, -7,  3]],
+            [[-4, -4,  4, -4],
+            [ 1, -4,  1, -5]],
+        ]),
+        np.array([
+            [[True, False, False, True],
+            [True, False, False, True]],
+            [[True, True, False, True],
+            [True, True, True, False]],
+        ], dtype=bool)
+    ],
+    "INT4": [
+        np.array([
+            [[  5,   9,   3,  -6],
+            [  1,   5,   9,  10]],
+            [[ 10,  10,  -3,   0],
+            [ -8,  -5, -12,  -5]],
+        ]),
+        np.array([
+            [[True, False, True, True],
+            [True, True, False, False]],
+            [[False, False, True, True],
+            [True, True, False, True]],
+        ], dtype=bool)
+    ],
+    "INT8": [
+        np.array([
+            [[-143,  140,   54, -217],
+            [  22,  186,   72, -175]],
+            [[-126,   -6,  115,  240],
+            [-87, -159,  128, -178]],
+        ]),
+        np.array([
+            [[False, False, True, False],
+            [True, False, True, False]],
+            [[True, True, True, False],
+            [True, False, False, False]],
+        ], dtype=bool)
+    ],
+    "INT16": [
+        np.array([
+            [[ 36863,   2676,   2728, -61500],
+            [ 24314,  18040, -39438,  64013]],
+            [[ 28824, -38855,  46308, -50728],
+            [-50275, -48853, -42034, -44384]],
+        ]),
+        np.array([
+            [[False, True, True, False],
+            [True, True, False, False]],
+            [[True, False, False, False],
+            [False, False, False, False]],
+        ], dtype=bool)
+    ],
+    "FIXED<4,2>": [
+        np.array([
+            [[1.8, 1.5, -0.25, 0],
+            [-1.1, -2, 1.75, 0.1]],
+            [[-1.5, 1.6, 0.5, 0.1],
+            [0.4, 0.001, 3.03, 1.75]],
+        ]),
+        np.array([
+            [[False, True, True, True],
+            [False, True, True, False]],
+            [[True, False, True, False],
+            [False, False, False, True]],
+        ], dtype=bool)
+    ],
+    "FLOAT<4,3>": [
+        np.array([
+            [0.0, 0.5, 1.875, -1.5],
+            [1.8, -512.0, 0.013671875, 0.0087890625],
+            [0.001953125, 0.0009765625, 2.0, 1.25]
+        ]),
+        np.array([
+            [True, True, True, True],
+            [False, False, True, False],
+            [True, False, True, True]
+        ])
+    ],
+    "FLOAT<4,0>": [
+        np.array([
+            [0.0, 0.5, 0.75],
+            [0.015625, 0.0078125, 0.0625]
+        ]),
+        np.array([
+            [True, True, False],
+            [True, False, True]
+        ])
+    ],
+    "FLOAT<4,3,5>": [
+        np.array([
+            [0.0, 0.5, 1.875],
+            [-1.5, 1.8, -512.0]
+        ]),
+        np.array([
+            [True, True, True],
+            [True, False, True]
+        ])
+    ],
+    "FLOAT<4,0,5>": [
+        np.array([0.0, 0.0625, 0.03125]),
+        np.array([True, True, False])
+    ]
+}
+
+@pytest.mark.parametrize("datatype", vectorize_details.keys())
+def test_vectorized_allowed(datatype):
+    input_values, golden_out = vectorize_details[datatype]
+    produced_out = DataType[datatype].allowed(input_values)
+    assert np.all(golden_out == produced_out)


### PR DESCRIPTION
- vectorized implementation of value checking for all QONNX datatypes
- added value checking test cases with multi-dimensional numpy arrays
- use vectorized value checking in `sanitize_quant_values`
- TODO: check for any other internal value checks which might need to be replaced with the vectorized versions.