### PR TITLE
Fix crash in GiveReadableTensorNames

### DIFF
--- a/src/qonnx/transformation/general.py
+++ b/src/qonnx/transformation/general.py
@@ -147,6 +147,19 @@ class GiveRandomTensorNames(Transformation):
         return (model, False)
 
 
+class GiveUniqueTensorNames(Transformation):
+    """Give unique tensor names to all tensors."""
+
+    def apply(self, model):
+        names = model.get_all_tensor_names()
+        i = 0
+        for name in names:
+            model.rename_tensor(name, f"tensor_{i}")
+            i += 1
+        # return model_was_changed = False as single iteration is always enough
+        return (model, False)
+
+
 class GiveReadableTensorNames(Transformation):
     """Give more human-readable names to all internal tensors. You should
     apply GiveUniqueNodeNames prior to this transform to avoid empty node names,
@@ -155,7 +168,7 @@ class GiveReadableTensorNames(Transformation):
     def apply(self, model):
         # to ensure we can use rename_tensor safely (without renaming existing
         # tensors) we start by giving random names to all tensors
-        model = model.transform(GiveRandomTensorNames())
+        model = model.transform(GiveUniqueTensorNames())
         graph = model.graph
         for n in graph.node:
             assert n.name != "", "Found empty node name"


### PR DESCRIPTION
In rare cases, `GiveReadableTensorNames` can crash due to a collision of two tensors with the same randomly generated name. This is the case, because `model.rename_tensor` assumes that each tensor name in the graph is unique. If two tensors get assigned the same random name by `GiveRandomTensorNames` this condition is violated and the code crashes.

In this PR I fixed the problem by introducing the `GiveUniqueTensorNames` transformation, which just numbers all tensors. As a result, the naming is unique and can be used in `GiveReadableTensorNames`.

(Additionally, just iterating all tensors in a graph and assigning numbers is also a bit faster than randomly generating strings for names.) 