### PR TITLE
Use weight shape as backup if kernel_shape attribute doesn't exist

### DIFF
--- a/src/qonnx/custom_op/channels_last/conv.py
+++ b/src/qonnx/custom_op/channels_last/conv.py
@@ -67,7 +67,10 @@ class Conv(ChannelsLastWrappedOp):
         ndim = len(ishape)
         assert ndim == 3 or ndim == 4, "ChannelsLast Conv currently only supports 3D and 4D input tensors."
 
-        kernel_shape = self.get_nodeattr("kernel_shape")
+        try:
+            kernel_shape = self.get_nodeattr("kernel_shape")
+        except Exception:
+            kernel_shape = model.get_tensor_shape(self.onnx_node.input[1])[1:-1]
         strides = self.get_nodeattr("strides")
         dilations = self.get_nodeattr("dilations")
         # Get the input shape from the previous tensor


### PR DESCRIPTION
Since Conv nodes aren't required to have a "kernel_shape" attribute, this use the weight input shape as a backup also in our custom up. I believe the behavior should be the same as for standard Conv. Please check if the logic is correct.