### PR TITLE
fix(qonnx): handle scalar zpt for per-tensor bias quantization

### DIFF
--- a/src/qonnx/transformation/extract_conv_bias.py
+++ b/src/qonnx/transformation/extract_conv_bias.py
@@ -78,7 +78,7 @@ class ExtractBiasFromConv(Transformation):
                         if quant_scale.shape != (1,):
                             model.set_initializer(producer.input[1], quant_scale.reshape(add_shape))
                         quant_zpt = model.get_initializer(producer.input[2])
-                        if quant_zpt.shape != (1,):
+                        if quant_zpt.size != 1:
                             model.set_initializer(producer.input[2], quant_zpt.reshape(add_shape))
                         model.set_tensor_shape(producer.output[0], add_shape)
 


### PR DESCRIPTION
When Conv bias quantization is enabled with per-tensor quantization, exported QONNX models may not always use the same shape representation for scale and zero-point. The scale may be stored as (1,), while the zero-point may be stored as ().

The previous logic relied on shape comparison against (1,), which could fail to catch this scalar zero-point representation. If this case is not handled explicitly, the subsequent reshape operation can fail because the zero-point shape is not normalized to the expected per-tensor form.

This PR makes the check semantically correct by treating both forms as valid per-tensor quantization parameters.