### PR TITLE
Enforce Python 3.10 minimum in package metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ package_dir =
     =src
 
 # Require a min/specific Python version (comma-separated conditions)
-# python_requires = >=3.10
+python_requires = >=3.10
 
 # Add here dependencies of your project (line-separated), e.g. requests>=2.2,<3.0.
 # Version specifiers like >=2.2,<3.0 avoid problems due to API changes in


### PR DESCRIPTION
## Summary

Enforce Python 3.10 as QONNX's minimum supported version by enabling the existing `python_requires = >=3.10` package metadata declaration.

This prevents package installers from selecting an incompatible QONNX release on Python 3.9 or older.

## Validation

- Confirmed `setup.cfg` parses `python_requires` as `>=3.10`
- Confirmed `git diff --check` passes
- Confirmed the commit changes only the existing `python_requires` line

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)